### PR TITLE
ci: add iOS deploy workflow for App Store Connect

### DIFF
--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -1,0 +1,127 @@
+name: iOS Deploy
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  SCHEME: App
+  WORKSPACE: ios/App/App.xcworkspace
+  XCODEPROJ: ios/App/App.xcodeproj
+  BUNDLE_ID: com.johncorser.crosswords
+
+jobs:
+  deploy:
+    name: Deploy to App Store Connect
+    runs-on: macos-26-xlarge
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Provide amplify_outputs.json
+        env:
+          AMPLIFY_OUTPUTS_BASE64: ${{ secrets.AMPLIFY_OUTPUTS_BASE64 }}
+        run: echo "$AMPLIFY_OUTPUTS_BASE64" | base64 -d > src/amplify_outputs.json
+
+      - name: Build SvelteKit and sync to Capacitor iOS
+        run: |
+          CAPACITOR_BUILD=1 npm run build
+          npx cap sync ios
+
+      - name: Install CocoaPods
+        working-directory: ios/App
+        run: pod install
+
+      - name: Write App Store Connect API key
+        run: |
+          mkdir -p ~/private_keys
+          echo "${{ secrets.ASC_KEY_CONTENT }}" > ~/private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
+
+      - name: Increment build number
+        working-directory: ios/App
+        run: |
+          BUILD_NUM=$(date +%Y%m%d%H%M)
+          agvtool new-version -all $BUILD_NUM
+          echo "Set build number to $BUILD_NUM"
+
+      - name: Archive and upload (auto-bump version on conflict)
+        run: |
+          cat > /tmp/ExportOptions.plist << 'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>destination</key>
+              <string>upload</string>
+              <key>signingStyle</key>
+              <string>automatic</string>
+              <key>teamID</key>
+              <string>${{ secrets.TEAM_ID }}</string>
+          </dict>
+          </plist>
+          PLIST
+
+          archive_and_upload() {
+            xcodebuild archive \
+              -workspace "$WORKSPACE" \
+              -scheme "$SCHEME" \
+              -destination "generic/platform=iOS" \
+              -archivePath ~/Desktop/SmallCrosswords.xcarchive \
+              -allowProvisioningUpdates \
+              -authenticationKeyPath ~/private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8 \
+              -authenticationKeyID ${{ secrets.ASC_KEY_ID }} \
+              -authenticationKeyIssuerID ${{ secrets.ASC_ISSUER_ID }} \
+              -quiet
+
+            xcodebuild -exportArchive \
+              -archivePath ~/Desktop/SmallCrosswords.xcarchive \
+              -exportOptionsPlist /tmp/ExportOptions.plist \
+              -exportPath ~/Desktop/export \
+              -allowProvisioningUpdates \
+              -authenticationKeyPath ~/private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8 \
+              -authenticationKeyID ${{ secrets.ASC_KEY_ID }} \
+              -authenticationKeyIssuerID ${{ secrets.ASC_ISSUER_ID }} 2>&1
+          }
+
+          OUTPUT=$(archive_and_upload) && echo "$OUTPUT" && exit 0
+
+          if echo "$OUTPUT" | grep -qi "version.*already exists\|already been uploaded\|redundant binary\|train.*closed\|higher version"; then
+            echo "⚠️ Version conflict, bumping minor version..."
+            CURRENT=$(grep -m 1 'MARKETING_VERSION' "$XCODEPROJ/project.pbxproj" | sed 's/.*= *\(.*\);/\1/')
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+            NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            sed -i '' "s/MARKETING_VERSION = ${CURRENT}/MARKETING_VERSION = ${NEW_VERSION}/g" "$XCODEPROJ/project.pbxproj"
+            echo "Bumped $CURRENT → $NEW_VERSION"
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add "$XCODEPROJ/project.pbxproj"
+            git commit -m "chore(ios): bump version to $NEW_VERSION [skip ci]"
+            git push origin main
+
+            rm -rf ~/Desktop/SmallCrosswords.xcarchive ~/Desktop/export
+            archive_and_upload
+          else
+            echo "$OUTPUT"
+            exit 1
+          fi

--- a/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "504EC3031FED79650016851F"
+               BuildableName = "Small Crosswords.app"
+               BlueprintName = "Small Crosswords"
+               ReferencedContainer = "container:App.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "504EC3031FED79650016851F"
+            BuildableName = "Small Crosswords.app"
+            BlueprintName = "Small Crosswords"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "504EC3031FED79650016851F"
+            BuildableName = "Small Crosswords.app"
+            BlueprintName = "Small Crosswords"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- New `.github/workflows/ios-deploy.yml` triggers on successful CI runs against `main` (via `workflow_run`) and on manual `workflow_dispatch`.
- Builds the SvelteKit web bundle (`CAPACITOR_BUILD=1 npm run build`), syncs to Capacitor iOS (`cap sync ios`), runs `pod install`, archives via `xcodebuild`, and uploads to App Store Connect using API-key auth.
- Auto-bumps the patch version when ASC rejects with "version already exists" and pushes the bump back to `main` with `[skip ci]`.
- Adds a shared `App.xcscheme` so `xcodebuild` can resolve the scheme in CI without user-specific Xcode state.

## Required repo secrets
- `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_CONTENT` — App Store Connect API key
- `TEAM_ID` — Apple Developer Team ID
- `AMPLIFY_OUTPUTS_BASE64` — already configured for CI

## Test plan
- [ ] Merge PR → existing CI passes on `main`
- [ ] `iOS Deploy` workflow fires automatically on the `CI` workflow's success
- [ ] Archive succeeds, build is uploaded to App Store Connect (TestFlight)
- [ ] On version conflict, patch version bumps and re-upload succeeds