### PR TITLE
fix(ios): skip TestFlight encryption-compliance prompt

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## Summary
Set `ITSAppUsesNonExemptEncryption=false` in `ios/App/App/Info.plist`. The app only uses Apple-provided HTTPS for network calls (Cognito + Lambda + standard `fetch`), which is exempt from US export compliance — declaring this in Info.plist tells App Store Connect the answer up-front so TestFlight stops asking on every build.

## Test plan
- [ ] Merge → next iOS Deploy run uploads without the export compliance question pending