### PR TITLE
feat(keyboard): toggle between alphabet and symbols on crossword keyboard

### DIFF
--- a/e2e/features/keyboard-symbols.feature
+++ b/e2e/features/keyboard-symbols.feature
@@ -1,0 +1,11 @@
+Feature: Toggle between alphabet and symbols on the on-screen keyboard
+
+  Scenario: User switches to symbols, types a symbol, switches back to letters, and types a letter
+    Given the user navigates to the preview page
+    When the user clicks the first cell of the puzzle
+    And the user toggles the on-screen keyboard to symbols mode
+    And the user taps the on-screen key "1"
+    Then the focused cell should contain "1"
+    When the user toggles the on-screen keyboard to alphabet mode
+    And the user taps the on-screen key "T"
+    Then the second cell of the puzzle should contain "T"

--- a/e2e/steps/keyboard-symbols.steps.ts
+++ b/e2e/steps/keyboard-symbols.steps.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+
+const { When, Then } = createBdd();
+
+When('the user toggles the on-screen keyboard to symbols mode', async ({ page }) => {
+	await page.locator('.svelte-keyboard .key--Page1').first().click();
+	await expect(page.locator('.svelte-keyboard .key--1').first()).toBeVisible();
+});
+
+When('the user toggles the on-screen keyboard to alphabet mode', async ({ page }) => {
+	await page.locator('.svelte-keyboard .key--Page0').first().click();
+	await expect(page.locator('.svelte-keyboard .key--T').first()).toBeVisible();
+});
+
+When('the user taps the on-screen key {string}', async ({ page }, value: string) => {
+	await page.locator(`.svelte-keyboard .key--${value}`).first().click();
+});
+
+Then('the focused cell should contain {string}', async ({ page }, value: string) => {
+	const focused = page.locator('g.cell.is-focused, g.cell-0-0').first();
+	await expect(focused.locator('text').first()).toHaveText(value);
+});
+
+Then('the second cell of the puzzle should contain {string}', async ({ page }, value: string) => {
+	const cell = page.locator('g.cell-1-0').first();
+	await expect(cell.locator('text').first()).toHaveText(value);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,10 @@ export default defineConfig({
 	grepInvert: hasCreds ? undefined : /@requires-credentials/,
 	use: {
 		baseURL: 'http://localhost:4173',
-		trace: 'on-first-retry'
+		trace: 'on-first-retry',
+		launchOptions: {
+			slowMo: process.env.SLOW_MO ? Number(process.env.SLOW_MO) : 0
+		}
 	},
 	webServer: {
 		command: 'npm run preview',

--- a/src/routes/components/crossword/helpers/cellLogic.js
+++ b/src/routes/components/crossword/helpers/cellLogic.js
@@ -32,7 +32,7 @@ export function getKeydownAction(e) {
 	if (modAction !== undefined) return modAction;
 	const special = getSpecialKeyAction(e);
 	if (special !== undefined) return special;
-	if (/^[a-zA-Z()]$/.test(e.key)) return { type: 'letter', value: e.key.toUpperCase() };
+	if (/^[\x21-\x7e]$/.test(e.key)) return { type: 'letter', value: e.key.toUpperCase() };
 	return getArrowAction(e.key);
 }
 

--- a/src/routes/components/crossword/helpers/cellLogic.test.js
+++ b/src/routes/components/crossword/helpers/cellLogic.test.js
@@ -90,8 +90,13 @@ describe('getKeydownAction', () => {
 
 	it('returns null for unhandled keys', () => {
 		expect(getKeydownAction(makeEvent({ key: 'Enter' }))).toBeNull();
-		expect(getKeydownAction(makeEvent({ key: '1' }))).toBeNull();
 		expect(getKeydownAction(makeEvent({ key: 'F5' }))).toBeNull();
+	});
+
+	it('returns letter action for digits and symbols', () => {
+		expect(getKeydownAction(makeEvent({ key: '1' }))).toEqual({ type: 'letter', value: '1' });
+		expect(getKeydownAction(makeEvent({ key: '!' }))).toEqual({ type: 'letter', value: '!' });
+		expect(getKeydownAction(makeEvent({ key: '@' }))).toEqual({ type: 'letter', value: '@' });
 	});
 });
 

--- a/src/routes/components/keyboard/layouts/azerty/crossword.js
+++ b/src/routes/components/keyboard/layouts/azerty/crossword.js
@@ -1,7 +1,22 @@
-const keys = (rows) => rows.flatMap((values, row) => values.map((value) => ({ row, value })));
+const keys = (rows, page) =>
+	rows.flatMap((values, row) =>
+		values.map((value) => (page !== undefined ? { row, value, page } : { row, value }))
+	);
 
-export default keys([
-	['a', 'z', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
-	['q', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm'],
-	['w', 'x', 'c', 'v', 'b', 'n', 'Backspace']
-]);
+export default [
+	...keys([
+		['a', 'z', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+		['q', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm'],
+		['w', 'x', 'c', 'v', 'b', 'n', 'Backspace'],
+		['Page1']
+	]),
+	...keys(
+		[
+			['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+			['!', '@', '#', '$', '%', '^', '&', '*', '(', ')'],
+			['-', '_', '=', '+', ';', ':', "'", '"', 'Backspace'],
+			['Page0']
+		],
+		1
+	)
+];

--- a/src/routes/components/keyboard/layouts/qwerty/crossword.js
+++ b/src/routes/components/keyboard/layouts/qwerty/crossword.js
@@ -1,10 +1,25 @@
-const keys = (rows) =>
+const keys = (rows, page) =>
 	rows.flatMap((values, row) =>
-		values.map((v) => ({ row, value: v.length === 1 ? v.toUpperCase() : v }))
+		values.map((v) => {
+			const value = v.length === 1 ? v.toUpperCase() : v;
+			return page !== undefined ? { row, value, page } : { row, value };
+		})
 	);
 
-export default keys([
-	['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
-	['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'],
-	['z', 'x', 'c', 'v', 'b', 'n', 'm', 'Backspace']
-]);
+export default [
+	...keys([
+		['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+		['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'],
+		['z', 'x', 'c', 'v', 'b', 'n', 'm', 'Backspace'],
+		['Page1']
+	]),
+	...keys(
+		[
+			['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+			['!', '@', '#', '$', '%', '^', '&', '*', '(', ')'],
+			['-', '_', '=', '+', ';', ':', "'", '"', 'Backspace'],
+			['Page0']
+		],
+		1
+	)
+];

--- a/src/routes/components/keyboard/layouts/qwerty/crossword.test.js
+++ b/src/routes/components/keyboard/layouts/qwerty/crossword.test.js
@@ -16,16 +16,33 @@ describe('qwerty crossword keyboard layout', () => {
 		});
 	});
 
-	it('contains all 26 letters plus Backspace', () => {
-		const values = layout.map((k) => k.value);
+	it('page 0 contains all 26 letters plus Backspace', () => {
+		const page0 = layout.filter((k) => !k.page);
+		const values = page0.map((k) => k.value);
 		for (let i = 65; i <= 90; i++) {
 			expect(values).toContain(String.fromCharCode(i));
 		}
 		expect(values).toContain('Backspace');
 	});
 
-	it('has 3 rows (0, 1, 2)', () => {
-		const rows = new Set(layout.map((k) => k.row));
-		expect(rows).toEqual(new Set([0, 1, 2]));
+	it('page 0 includes a Page1 toggle key', () => {
+		const values = layout.filter((k) => !k.page).map((k) => k.value);
+		expect(values).toContain('Page1');
+	});
+
+	it('page 1 contains digits 0-9 and a Page0 toggle', () => {
+		const page1 = layout.filter((k) => k.page === 1);
+		const values = page1.map((k) => k.value);
+		for (const d of '0123456789') {
+			expect(values).toContain(d);
+		}
+		expect(values).toContain('Page0');
+	});
+
+	it('page 1 contains common symbols', () => {
+		const values = layout.filter((k) => k.page === 1).map((k) => k.value);
+		for (const s of ['!', '@', '#', '$', '%']) {
+			expect(values).toContain(s);
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Add a `Page1` key to the on-screen crossword keyboard that toggles to a numbers + symbols layout, with a `Page0` key to toggle back.
- Loosen the cell input filter (`getKeydownAction`) to accept printable ASCII, so cells also accept digits/symbols from a hardware keyboard.
- New Gherkin scenario taps `Page1`, types `1`, taps `Page0`, types `T`, asserting the focused cell receives each character.
- Add a `SLOW_MO` env var hook to `playwright.config.ts` for headed debugging (no-op when unset).

## Test plan
- [x] Unit tests pass (322 → 322+ with new layout coverage)
- [x] Coverage thresholds met (90%+ statements/branches/lines/functions)
- [x] CRAP score check passes (all functions ≤ 15)
- [x] E2E `keyboard-symbols` scenario passes locally headed (`SLOW_MO=1500`)
- [x] Existing preview-solve scenario still passes (regression check)