### PR TITLE
ci: bump actions to node24 runtimes + revoke stale iOS certs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'npm'
@@ -71,7 +71,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-report

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -53,6 +53,79 @@ jobs:
           mkdir -p ~/private_keys
           echo "${{ secrets.ASC_KEY_CONTENT }}" > ~/private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
 
+      - name: Revoke stale API-created certificates
+        run: |
+          python3 - << 'EOF'
+          import json, time, urllib.request, ssl
+          ctx = ssl.create_default_context()
+
+          key_id = "${{ secrets.ASC_KEY_ID }}"
+          issuer_id = "${{ secrets.ASC_ISSUER_ID }}"
+          key_path = f"/Users/runner/private_keys/AuthKey_{key_id}.p8"
+
+          # Inline minimal JWT (ES256) without PyJWT
+          import hashlib, hmac, struct, subprocess, tempfile, base64
+          def b64url(data):
+              return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+          header = b64url(json.dumps({"alg":"ES256","kid":key_id,"typ":"JWT"}).encode())
+          now = int(time.time())
+          payload = b64url(json.dumps({"iss":issuer_id,"iat":now,"exp":now+1200,"aud":"appstoreconnect-v1"}).encode())
+          signing_input = f"{header}.{payload}".encode()
+
+          # Sign with openssl
+          with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tf:
+              tf.write(signing_input)
+              tf.flush()
+              result = subprocess.run(
+                  ["openssl", "dgst", "-sha256", "-sign", key_path, tf.name],
+                  capture_output=True
+              )
+          # Convert DER signature to raw r||s (64 bytes)
+          der = result.stdout
+          # Parse DER SEQUENCE { INTEGER r, INTEGER s }
+          def parse_der_int(data, offset):
+              assert data[offset] == 0x02
+              length = data[offset+1]
+              value = data[offset+2:offset+2+length]
+              # Remove leading zero padding
+              while len(value) > 32 and value[0] == 0:
+                  value = value[1:]
+              # Pad to 32 bytes
+              value = b'\x00' * (32 - len(value)) + value
+              return value, offset + 2 + length
+
+          assert der[0] == 0x30
+          seq_len = der[1]
+          r, offset = parse_der_int(der, 2)
+          s, _ = parse_der_int(der, offset)
+          raw_sig = b64url(r + s)
+
+          token = f"{header}.{payload}.{raw_sig}"
+          headers_dict = {"Authorization": f"Bearer {token}"}
+
+          # List certificates
+          req = urllib.request.Request("https://api.appstoreconnect.apple.com/v1/certificates", headers=headers_dict)
+          resp = urllib.request.urlopen(req, context=ctx)
+          certs = json.loads(resp.read()).get("data", [])
+
+          api_certs = [c for c in certs if "Created via API" in c["attributes"].get("name", "")]
+          if not api_certs:
+              print("No stale API certificates to revoke.")
+          else:
+              print(f"Found {len(api_certs)} API-created certificates, revoking...")
+              for cert in api_certs:
+                  try:
+                      dreq = urllib.request.Request(
+                          f"https://api.appstoreconnect.apple.com/v1/certificates/{cert['id']}",
+                          headers=headers_dict, method="DELETE"
+                      )
+                      urllib.request.urlopen(dreq, context=ctx)
+                      print(f"  {cert['id']}: revoked")
+                  except Exception as e:
+                      print(f"  {cert['id']}: skip ({e})")
+          EOF
+
       - name: Increment build number
         working-directory: ios/App
         run: |

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: macos-26-xlarge
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'npm'


### PR DESCRIPTION
Follow-up to #29. Two CI/deploy hardening changes.

## 1. Bump GitHub Actions off the deprecated Node 20 runtime
GitHub flagged that `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/upload-artifact@v4` run on the deprecated Node 20 runtime (currently force-run on Node 24 with a warning, ahead of removal). Bumped to the latest majors that ship a Node 24 runtime, in both workflows:

- `actions/checkout` v4 → **v7**
- `actions/setup-node` v4 → **v6**
- `actions/upload-artifact` v4 → **v7**

Job Node version stays at 22 (`node-version: 22`) — that was never the issue; only the actions' internal runtime was.

## 2. Revoke stale API-created iOS certificates before archive
`ios-deploy.yml` uses automatic signing with `-allowProvisioningUpdates`, which mints a new distribution certificate via the App Store Connect API when none is usable. Apple caps accounts at **2 distribution certificates**, so these accumulate and eventually fail deploys with *"maximum number of certificates generated."*

Added a step (before archiving, using the existing `ASC_KEY_ID`/`ASC_ISSUER_ID`/`.p8` secrets — no new secrets) that lists certificates, filters to the "Created via API" ones, and revokes them so each run can mint a fresh cert. Ported from `johnpc/jpc.finance.native`.

## Note
Reviewed the rest of `jpc.finance.native`'s CI for portable gates — this repo already matches or beats everything else (line-limit, coverage, CRAP), except mutation testing, which was intentionally skipped.