### PR TITLE
fix(a11y): resolve all build + svelte-check warnings

### DIFF
--- a/src/routes/PuzzleHeader.svelte
+++ b/src/routes/PuzzleHeader.svelte
@@ -7,7 +7,11 @@
 
 <h3>
 	👋 {email.split('@')[0]}
-	<span id="logoutLink">(not you? <a href="#" on:click={() => onSignOut()}>sign out</a>)</span>
+	<span id="logoutLink"
+		>(not you? <button type="button" class="link-button" on:click={() => onSignOut()}
+			>sign out</button
+		>)</span
+	>
 </h3>
 {#if puzzleTitle || puzzleAuthor}
 	<div class="puzzle-info">
@@ -35,5 +39,14 @@
 	}
 	#logoutLink {
 		font-size: small;
+	}
+	.link-button {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		color: inherit;
+		text-decoration: underline;
+		cursor: pointer;
 	}
 </style>

--- a/src/routes/components/crossword/Cell.svelte
+++ b/src/routes/components/crossword/Cell.svelte
@@ -63,7 +63,9 @@
 	class:is-correct={showCheck && correct}
 	class:is-incorrect={showCheck && !correct}
 	transform={`translate(${x}, ${y})`}
-	tabIndex="0"
+	role="button"
+	aria-label={`Cell ${x + 1}, ${y + 1}`}
+	tabindex="0"
 	on:click={() => onFocusCell(index)}
 	on:keydown={onKeydown}
 	bind:this={element}

--- a/src/routes/components/crossword/ClueBar.svelte
+++ b/src/routes/components/crossword/ClueBar.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <div class="bar {custom}">
-	<button on:click={() => buttonHandler(currentClue.index! - 1)}>
+	<button aria-label="Previous clue" on:click={() => buttonHandler(currentClue.index! - 1)}>
 		<svg
 			width="24"
 			height="24"
@@ -35,8 +35,8 @@
 			<polyline points="15 18 9 12 15 6"></polyline>
 		</svg>
 	</button>
-	<p on:click={() => handleClueBarClicked(currentClue)}>{clue}</p>
-	<button on:click={() => buttonHandler(currentClue.index! + 1)}>
+	<button class="clue-text" on:click={() => handleClueBarClicked(currentClue)}>{clue}</button>
+	<button aria-label="Next clue" on:click={() => buttonHandler(currentClue.index! + 1)}>
 		<svg
 			width="24"
 			height="24"
@@ -62,11 +62,17 @@
 		align-items: center;
 	}
 
-	p {
+	.clue-text {
+		flex: 1;
 		padding: 0 1em;
 		line-height: 1.325;
 		font-family: var(--font);
 		font-size: 1.2em;
+		text-align: left;
+		cursor: pointer;
+		border: none;
+		color: var(--main-color);
+		background-color: transparent;
 	}
 
 	button {

--- a/src/routes/components/crossword/ClueBar.test.ts
+++ b/src/routes/components/crossword/ClueBar.test.ts
@@ -36,25 +36,21 @@ describe('ClueBar', () => {
 
 	it('dispatches nextClue with the next index when the right button is clicked', async () => {
 		const onNextClue = vi.fn();
-		const { container } = render(ClueBar, {
+		const { getByLabelText } = render(ClueBar, {
 			props: { currentClue },
 			events: { nextClue: (e) => onNextClue(e.detail) }
 		});
-		const buttons = container.querySelectorAll('button');
-		// second button is the "next" (chevron-right) control
-		await fireEvent.click(buttons[1]);
+		await fireEvent.click(getByLabelText('Next clue'));
 		expect(onNextClue).toHaveBeenCalledWith(currentClue.index + 1);
 	});
 
 	it('dispatches nextClue with the previous index when the left button is clicked', async () => {
 		const onNextClue = vi.fn();
-		const { container } = render(ClueBar, {
+		const { getByLabelText } = render(ClueBar, {
 			props: { currentClue },
 			events: { nextClue: (e) => onNextClue(e.detail) }
 		});
-		const buttons = container.querySelectorAll('button');
-		// first button is the "prev" (chevron-left) control
-		await fireEvent.click(buttons[0]);
+		await fireEvent.click(getByLabelText('Previous clue'));
 		expect(onNextClue).toHaveBeenCalledWith(currentClue.index - 1);
 	});
 

--- a/src/routes/components/crossword/Clues.test.ts
+++ b/src/routes/components/crossword/Clues.test.ts
@@ -86,18 +86,18 @@ describe('Clues', () => {
 		const { container } = render(Clues, { props: base });
 		// currentClue resolves to the across clue numbered 1 ("Feline"); the
 		// clue bar <p> shows that text.
-		const bar = container.querySelector('.bar p');
+		const bar = container.querySelector('.bar .clue-text');
 		expect(bar?.textContent).toContain('Feline');
 	});
 
 	it('updates the focused direction to down when a down clue is clicked', async () => {
 		const { getByText, container } = render(Clues, { props: base });
 		// initially the across clue ("Feline") is focused in the bar
-		expect(container.querySelector('.bar p')?.textContent).toContain('Feline');
+		expect(container.querySelector('.bar .clue-text')?.textContent).toContain('Feline');
 		await fireEvent.click(getByText(/Recipe qty\./));
 		// clicking the down clue (id 0-0) switches focusedDirection to 'down';
 		// the bar now reflects the down clue numbered 1 ("Recipe qty.").
-		expect(container.querySelector('.bar p')?.textContent).toContain('Recipe qty.');
+		expect(container.querySelector('.bar .clue-text')?.textContent).toContain('Recipe qty.');
 	});
 
 	it('focuses the clicked clue button (is-direction-focused) after a click', async () => {
@@ -107,7 +107,7 @@ describe('Clues', () => {
 		expect(recipeButton).not.toHaveClass('is-direction-focused');
 		await fireEvent.click(recipeButton!);
 		// after the click the down direction (and clue) is focused
-		expect(container.querySelector('.bar p')?.textContent).toContain('Recipe qty.');
+		expect(container.querySelector('.bar .clue-text')?.textContent).toContain('Recipe qty.');
 		expect(recipeButton).toHaveClass('is-direction-focused');
 	});
 });

--- a/src/routes/components/crossword/CompletedMessage.svelte
+++ b/src/routes/components/crossword/CompletedMessage.svelte
@@ -6,6 +6,7 @@
 	export let showConfetti = true;
 
 	let isOpen = true;
+	const close = () => (isOpen = false);
 </script>
 
 {#if isOpen}
@@ -15,7 +16,7 @@
 				<slot />
 			</div>
 
-			<button on:click={() => (isOpen = false)}>View puzzle</button>
+			<button on:click={close}>View puzzle</button>
 		</div>
 
 		{#if showConfetti}
@@ -24,7 +25,15 @@
 			</div>
 		{/if}
 	</div>
-	<div class="curtain" transition:fade={{ duration: 250 }} on:click={() => (isOpen = false)}></div>
+	<div
+		class="curtain"
+		role="button"
+		tabindex="-1"
+		aria-label="Dismiss"
+		transition:fade={{ duration: 250 }}
+		on:click={close}
+		on:keydown={(e) => (e.key === 'Enter' || e.key === ' ' ? close() : null)}
+	></div>
 {/if}
 
 <style>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -55,7 +55,10 @@
 {#if isLoading}
 	<p style="margin: auto"><SyncLoader size="60" color="palevioletred" unit="px" duration="1s" /></p>
 {:else if completedPuzzles.length === 0}
-	<p>You have not completed any puzzles. <a href="#" on:click={() => goto('/')}>Go Back</a></p>
+	<p>
+		You have not completed any puzzles.
+		<button type="button" class="link-button" on:click={() => goto('/')}>Go Back</button>
+	</p>
 {:else}
 	<Calendar {plugins} options={getCalendarOptions(streakInfo)} />
 	<HistoryStats
@@ -71,7 +74,11 @@
 <hr />
 <div id="privacy">
 	<p>We value your <a href="/privacy-policy.html">privacy</a>.</p>
-	<p><a href="#" on:click={() => handleDeleteAllData()}>Delete my account and all my data.</a></p>
+	<p>
+		<button type="button" class="link-button" on:click={() => handleDeleteAllData()}
+			>Delete my account and all my data.</button
+		>
+	</p>
 </div>
 
 <style>
@@ -82,6 +89,15 @@
 		margin-bottom: 5px;
 	}
 	#privacy {
-		text-size: xx-small;
+		font-size: xx-small;
+	}
+	.link-button {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		color: inherit;
+		text-decoration: underline;
+		cursor: pointer;
 	}
 </style>

--- a/src/routes/login/SignInForm.svelte
+++ b/src/routes/login/SignInForm.svelte
@@ -33,7 +33,7 @@
 	<br /><br />
 	<label for="password">Password&nbsp;&nbsp;</label>
 	<input required type="password" id="password" bind:value={password} />
-	<a href="#" on:click={onShowForgotPassword}>forgot?</a>
+	<button type="button" class="link-button" on:click={onShowForgotPassword}>forgot?</button>
 	<hr />
 	<button type="submit" on:click={() => tryOrAlert(onLogin)}>Log in</button>
 </form>

--- a/src/routes/login/login.css
+++ b/src/routes/login/login.css
@@ -65,3 +65,13 @@
 		0 1px 1px rgba(0, 0, 0, 0.25);
 	cursor: not-allowed;
 }
+
+.link-button {
+	background: none;
+	border: none;
+	padding: 0;
+	font: inherit;
+	color: inherit;
+	text-decoration: underline;
+	cursor: pointer;
+}


### PR DESCRIPTION
Clears the 12 a11y/CSS warnings that `npm run build` and `npm run check` emit. Both are now **warning-free** (0 errors, 0 warnings).

## Changes

- **Real CSS bug:** `text-size: xx-small` → `font-size: xx-small` (history privacy block — `text-size` isn't a property).
- **Button-like links → real buttons** (styled as links via a `.link-button` class): history "Go Back" / "Delete my account", PuzzleHeader "sign out", SignInForm "forgot?". Fixes the `'#' is not a valid href` warnings and gives proper keyboard/AT semantics.
- **ClueBar:** added `aria-label` to the prev/next icon buttons; converted the click-handled `<p>` clue text into a `<button class="clue-text">`.
- **Cell:** the interactive `<g>` now has `role="button"`, `aria-label`, and lowercase `tabindex`.
- **CompletedMessage:** the click-to-dismiss curtain `<div>` got `role="button"`, `tabindex`, `aria-label`, and an Enter/Space keydown handler.

## Tests
Updated the affected component tests to query by `aria-label` / `.clue-text` instead of DOM order (the extra ClueBar button shifted indices).

## Verification (all green)
- [x] `npm run lint`
- [x] `npm run check` — **0 errors, 0 warnings** (was 12 warnings)
- [x] `npm run build` — **no warnings**
- [x] 563 unit tests
- [x] coverage gate + CRAP
- [x] 5 Playwright e2e tests