### PR TITLE
style(clue-bar): add min-height, larger centered clue text

### DIFF
--- a/src/routes/components/crossword/ClueBar.svelte
+++ b/src/routes/components/crossword/ClueBar.svelte
@@ -60,15 +60,16 @@
 		justify-content: space-between;
 		background-color: var(--secondary-highlight-color);
 		align-items: center;
+		min-height: 4.5em;
 	}
 
 	.clue-text {
 		flex: 1;
 		padding: 0 1em;
-		line-height: 1.325;
+		line-height: 1.5;
 		font-family: var(--font);
-		font-size: 1.2em;
-		text-align: left;
+		font-size: 1.4em;
+		text-align: center;
 		cursor: pointer;
 		border: none;
 		color: var(--main-color);


### PR DESCRIPTION
## Summary
- Added `min-height: 4.5em` to the clue bar for a consistent ~3-line minimum height
- Bumped clue text font-size from `1.2em` to `1.4em` for better readability
- Centered the clue text instead of left-aligning

## Test plan
- [x] Verify clue bar has consistent height even with short clues
- [x] Confirm text is visually centered and larger
- [x] Check layout on mobile viewport sizes