### PR TITLE
fix(ios): disable status bar tap scroll-to-top

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -7,8 +7,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        if let window = window,
+           let rootViewController = window.rootViewController as? CAPBridgeViewController {
+            rootViewController.webView?.scrollView.scrollsToTop = false
+        }
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
@@ -23,10 +29,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
     func applicationWillTerminate(_ application: UIApplication) {


### PR DESCRIPTION
## Summary
- Disables the default iOS behavior where tapping the status bar scrolls the page to the top
- Sets `scrollsToTop = false` on the WKWebView's scroll view in `applicationDidBecomeActive`
- Prevents jarring scroll jumps when accidentally tapping the top of the phone during puzzle solving

## Test plan
- [ ] Build and run on iOS device/simulator
- [ ] Tap the status bar while scrolled down in a puzzle — should no longer jump to top
- [ ] Verify normal scrolling still works as expected