### PR TITLE
fix(sql-queries): skip corrupt puzzles when serving nextPuzzle

### DIFF
--- a/amplify/function/sql-queries/handler.ts
+++ b/amplify/function/sql-queries/handler.ts
@@ -1,5 +1,6 @@
 import { Handler } from 'aws-lambda';
 import mysql from 'mysql2/promise';
+import { isValidPuzzle } from './puzzle-validator';
 
 const getConnection = async () => {
 	const connectionString = process.env.SQL_CONNECTION_STRING!;
@@ -40,6 +41,9 @@ export const handler: Handler = async (event) => {
 		}
 
 		if (query === 'nextPuzzle' && profileId) {
+			// Pull a small window of unplayed puzzles (newest first) and serve the
+			// first valid one, skipping any corrupt rows (e.g. all-black, clueless
+			// puzzles). Guards every client without a release.
 			const [rows] = await conn.execute(
 				`
 				SELECT p.id, p.puz_json as puzJson
@@ -47,14 +51,16 @@ export const handler: Handler = async (event) => {
 				LEFT JOIN user_puzzles up ON p.id = up.puzzle_id AND up.profile_id = ?
 				WHERE up.id IS NULL
 				ORDER BY p.created_at DESC
-				LIMIT 1
+				LIMIT 10
 			`,
 				[profileId]
 			);
-			const result = Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
-			if (result && typeof result === 'object' && 'puzJson' in result) {
-				result.puzJson = JSON.parse(result.puzJson as string);
+			const candidates = Array.isArray(rows) ? (rows as { id: string; puzJson: string }[]) : [];
+			const valid = candidates.find((row) => isValidPuzzle(row.puzJson));
+			if (!valid) {
+				return { statusCode: 200, body: JSON.stringify(null) };
 			}
+			const result = { ...valid, puzJson: JSON.parse(valid.puzJson) };
 			return { statusCode: 200, body: JSON.stringify(result) };
 		}
 

--- a/amplify/function/sql-queries/puzzle-validator.test.ts
+++ b/amplify/function/sql-queries/puzzle-validator.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { fullyDecode, countClues, isValidPuzzle } from './puzzle-validator';
+
+const goodAi = {
+	header: { title: 'Good', author: 'robot' },
+	puzzle: { solution: 'PODXXEROSXREUPSXOSAYXXETD', state: '' },
+	clues: { across: { '1': {}, '2': {} }, down: { '3': {}, '4': {} } }
+};
+
+const goodLegacy = {
+	header: { title: null, numberOfClues: 10 },
+	puzzle: { solution: 'POD..EROS.REUPS.OSAY..ETD', state: '' },
+	details: { clues: new Array(10).fill({}) }
+};
+
+const blackMini = {
+	header: { title: 'Black Mini', numberOfClues: 0 },
+	puzzle: { solution: '.........................', state: '' },
+	clues: { across: {}, down: {} },
+	details: { clues: [] }
+};
+
+describe('fullyDecode', () => {
+	it('parses a plain object', () => {
+		expect(fullyDecode(goodAi)).toEqual(goodAi);
+	});
+	it('parses a single-encoded string', () => {
+		expect(fullyDecode(JSON.stringify(goodAi))).toEqual(goodAi);
+	});
+	it('parses a double-encoded string (legacy seed shape)', () => {
+		expect(fullyDecode(JSON.stringify(JSON.stringify(goodLegacy)))).toEqual(goodLegacy);
+	});
+	it('returns null for unparseable input', () => {
+		expect(fullyDecode('{not json')).toBeNull();
+	});
+});
+
+describe('countClues', () => {
+	it('counts AI across/down map shape', () => {
+		expect(countClues(goodAi)).toBe(4);
+	});
+	it('counts legacy details.clues array shape', () => {
+		expect(countClues(goodLegacy)).toBe(10);
+	});
+	it('returns 0 for an empty puzzle', () => {
+		expect(countClues(blackMini)).toBe(0);
+	});
+	it('counts a top-level clues array', () => {
+		expect(countClues({ clues: [{}, {}, {}] })).toBe(3);
+	});
+	it('handles a map with only across (down missing)', () => {
+		expect(countClues({ clues: { across: { '1': {}, '2': {} } } })).toBe(2);
+	});
+	it('returns 0 for null/non-object input', () => {
+		expect(countClues(null)).toBe(0);
+		expect(countClues('nope')).toBe(0);
+	});
+	it('returns 0 when clues is a primitive', () => {
+		expect(countClues({ clues: 5 })).toBe(0);
+	});
+	it('takes the larger of map vs details counts', () => {
+		expect(countClues({ clues: { across: { '1': {} } }, details: { clues: [{}, {}, {}] } })).toBe(
+			3
+		);
+	});
+});
+
+describe('isValidPuzzle', () => {
+	it('accepts a valid AI puzzle', () => {
+		expect(isValidPuzzle(goodAi)).toBe(true);
+	});
+	it('accepts a valid legacy puzzle (double-encoded)', () => {
+		expect(isValidPuzzle(JSON.stringify(JSON.stringify(goodLegacy)))).toBe(true);
+	});
+	it('rejects an all-black, clueless puzzle', () => {
+		expect(isValidPuzzle(JSON.stringify(blackMini))).toBe(false);
+	});
+	it('rejects a puzzle with clues but an all-dot solution', () => {
+		const bogus = { ...goodAi, puzzle: { solution: '.........................', state: '' } };
+		expect(isValidPuzzle(bogus)).toBe(false);
+	});
+	it('rejects undecodable input', () => {
+		expect(isValidPuzzle('{not json')).toBe(false);
+	});
+});

--- a/amplify/function/sql-queries/puzzle-validator.ts
+++ b/amplify/function/sql-queries/puzzle-validator.ts
@@ -1,0 +1,55 @@
+/**
+ * Guards against serving corrupt puzzles (e.g. all-black grids with no clues,
+ * such as the "Black Mini" rows that slipped in from the crosshare seed feed).
+ *
+ * Puzzle JSON reaches us in two historical shapes, and `puz_json` may be
+ * double-encoded (a JSON string holding JSON), so we fully decode first:
+ *   - AI/generated shape: { clues: { across: {...}, down: {...} }, ... }
+ *   - legacy seed shape:   { details: { clues: [...] }, header: {...}, ... }
+ */
+
+/** Parse repeatedly until we reach a non-string value (handles double-encoding). */
+export function fullyDecode(raw: unknown): unknown {
+	let value = raw;
+	for (let i = 0; i < 4 && typeof value === 'string'; i++) {
+		try {
+			value = JSON.parse(value);
+		} catch {
+			return null;
+		}
+	}
+	return value;
+}
+
+/** Number of own keys in an object, or 0 for anything that isn't one. */
+function keyCount(value: unknown): number {
+	return value && typeof value === 'object' ? Object.keys(value).length : 0;
+}
+
+/** Clues in the AI shape: { clues: { across: {...}, down: {...} } }. */
+function countMapClues(clues: unknown): number {
+	if (!clues || Array.isArray(clues) || typeof clues !== 'object') return 0;
+	const { across, down } = clues as Record<string, unknown>;
+	return keyCount(across) + keyCount(down);
+}
+
+/** Count clues across both known puzzle shapes. */
+export function countClues(pj: any): number {
+	if (!pj || typeof pj !== 'object') return 0;
+	const mapClues = Array.isArray(pj.clues) ? pj.clues.length : countMapClues(pj.clues);
+	const detailClues = Array.isArray(pj.details?.clues) ? pj.details.clues.length : 0;
+	return Math.max(mapClues, detailClues);
+}
+
+/**
+ * A puzzle is playable when it decodes, has at least one clue, and its solution
+ * grid contains real letters (not an all-black `.`/`-` grid).
+ */
+export function isValidPuzzle(rawPuzJson: unknown): boolean {
+	const pj: any = fullyDecode(rawPuzJson);
+	if (!pj || typeof pj !== 'object') return false;
+	if (countClues(pj) === 0) return false;
+	const solution: string = pj.puzzle?.solution ?? '';
+	if (solution.length > 0 && /^[.\-\s]+$/.test(solution)) return false;
+	return true;
+}

--- a/src/routes/Puzzle.svelte
+++ b/src/routes/Puzzle.svelte
@@ -28,6 +28,7 @@
 		puzzleAuthor = '';
 	let crosswordComplete = false,
 		showAppKeyboard = true;
+	let outOfPuzzles = false;
 	let cancelTimer: (() => void) | null = null;
 	const tick = () => void timeInSeconds++;
 	const isComplete = () => isPuzzleComplete;
@@ -53,6 +54,10 @@
 		initializePuzzle(getCurrentUser, getOrCreateProfile, {
 			onAuthenticated(p, puzzle) {
 				profile = p;
+				if (!puzzle) {
+					outOfPuzzles = true;
+					return;
+				}
 				clues = puzzle.clues;
 				puzzleId = puzzle.id;
 				puzzleTitle = puzzle.title || '';
@@ -75,20 +80,35 @@
 		localStorage.setItem('showAppKeyboard', String(showAppKeyboard));
 	};
 	const onNextPuzzle = async () => {
-		timeInSeconds = 0;
-		usedCheck = usedReveal = usedClear = false;
-		isPuzzleComplete = false;
-		const puzzle = await loadNextPuzzle(profile.id);
-		clues = puzzle.clues;
-		puzzleId = puzzle.id;
-		puzzleTitle = puzzle.title || '';
-		puzzleAuthor = puzzle.author || '';
-		startTimer();
+		try {
+			const puzzle = await loadNextPuzzle(profile.id);
+			if (!puzzle) {
+				outOfPuzzles = true;
+				return;
+			}
+			timeInSeconds = 0;
+			usedCheck = usedReveal = usedClear = false;
+			isPuzzleComplete = false;
+			clues = puzzle.clues;
+			puzzleId = puzzle.id;
+			puzzleTitle = puzzle.title || '';
+			puzzleAuthor = puzzle.author || '';
+			startTimer();
+		} catch (e) {
+			console.error('Error loading next puzzle:', e);
+			toast.push('Error loading the next puzzle. Please try again.');
+		}
 	};
 	const onSignOut = () => performSignOut(signOut, () => void (clues = []));
 </script>
 
-{#if clues.length === 0}
+{#if outOfPuzzles}
+	<PuzzleHeader email={profile.email} puzzleTitle="" puzzleAuthor="" {onSignOut} />
+	<p style="text-align: center; padding: 2rem;">
+		You've completed every available puzzle! 🎉<br />
+		Check back soon for more.
+	</p>
+{:else if clues.length === 0}
 	<p><SyncLoader size="60" color="palevioletred" unit="px" duration="1s" /></p>
 {:else}
 	<PuzzleHeader email={profile.email} {puzzleTitle} {puzzleAuthor} {onSignOut} />

--- a/src/routes/helpers/puzzleInit.ts
+++ b/src/routes/helpers/puzzleInit.ts
@@ -2,13 +2,13 @@ import { haptic } from './haptics';
 import type { CrosswordClues } from './types/types';
 import { getNextPuzzle } from './sql/getNextPuzzle';
 
-export const loadNextPuzzle = async (profileId: string): Promise<CrosswordClues> => {
+export const loadNextPuzzle = async (profileId: string): Promise<CrosswordClues | null> => {
 	haptic();
 	return getNextPuzzle(profileId);
 };
 
 export interface InitPuzzleCallbacks {
-	onAuthenticated: (profile: { id: string; email: string }, puzzle: CrosswordClues) => void;
+	onAuthenticated: (profile: { id: string; email: string }, puzzle: CrosswordClues | null) => void;
 	onUnauthenticated: () => void;
 	onError: (e: unknown) => void;
 }

--- a/src/routes/helpers/sql/getNextPuzzle.test.ts
+++ b/src/routes/helpers/sql/getNextPuzzle.test.ts
@@ -50,10 +50,20 @@ describe('getNextPuzzle', () => {
 		});
 
 		const result = await getNextPuzzle('profile-123');
-		expect(result.id).toBe('puzzle-1');
-		expect(result.title).toBe('Daily Puzzle');
-		expect(result.author).toBe('Test Author');
-		expect(result.clues).toHaveLength(2);
+		expect(result).not.toBeNull();
+		expect(result!.id).toBe('puzzle-1');
+		expect(result!.title).toBe('Daily Puzzle');
+		expect(result!.author).toBe('Test Author');
+		expect(result!.clues).toHaveLength(2);
+	});
+
+	it('returns null when the server has no valid puzzle', async () => {
+		mockSend.mockResolvedValueOnce({
+			Payload: new TextEncoder().encode(JSON.stringify({ body: JSON.stringify(null) }))
+		});
+
+		const result = await getNextPuzzle('profile-123');
+		expect(result).toBeNull();
 	});
 
 	it('handles pre-parsed puzJson', async () => {
@@ -72,8 +82,9 @@ describe('getNextPuzzle', () => {
 		});
 
 		const result = await getNextPuzzle('profile-123');
-		expect(result.id).toBe('puzzle-2');
-		expect(result.clues).toHaveLength(1);
+		expect(result).not.toBeNull();
+		expect(result!.id).toBe('puzzle-2');
+		expect(result!.clues).toHaveLength(1);
 	});
 
 	it('throws when function name is missing', async () => {

--- a/src/routes/helpers/sql/getNextPuzzle.ts
+++ b/src/routes/helpers/sql/getNextPuzzle.ts
@@ -3,8 +3,12 @@ import { invokeSqlQuery } from './invokeSqlQuery';
 
 type RawPuzzle = { id: string; puzJson: string | object };
 
-export const getNextPuzzle = async (profileId: string): Promise<CrosswordClues> => {
-	const puzzleData = await invokeSqlQuery<RawPuzzle>({ query: 'nextPuzzle', profileId });
+export const getNextPuzzle = async (profileId: string): Promise<CrosswordClues | null> => {
+	const puzzleData = await invokeSqlQuery<RawPuzzle | null>({ query: 'nextPuzzle', profileId });
+	// Server returns null when there's no valid unplayed puzzle (catalog
+	// exhausted, or only corrupt rows remain). Surface it as "no puzzle" rather
+	// than crashing on a missing puzJson.
+	if (!puzzleData || puzzleData.puzJson == null) return null;
 	const puzData =
 		typeof puzzleData.puzJson === 'string' ? JSON.parse(puzzleData.puzJson) : puzzleData.puzJson;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
 	test: {
 		include: [
 			'src/**/*.{test,spec}.{js,ts}',
-			'amplify/function/generate-puzzle/**/*.{test,spec}.{js,ts}'
+			'amplify/function/generate-puzzle/**/*.{test,spec}.{js,ts}',
+			'amplify/function/sql-queries/**/*.{test,spec}.{js,ts}'
 		],
 		globals: true,
 		environment: 'jsdom',
@@ -34,7 +35,11 @@ export default defineConfig({
 			},
 			// Both the .ts/.js logic layer and .svelte components are gated. Component
 			// logic is unit-tested via @testing-library/svelte render tests.
-			include: ['src/**/*.{js,ts,svelte}', 'amplify/function/generate-puzzle/**/*.ts'],
+			include: [
+				'src/**/*.{js,ts,svelte}',
+				'amplify/function/generate-puzzle/**/*.ts',
+				'amplify/function/sql-queries/puzzle-validator.ts'
+			],
 			exclude: [
 				'src/app.d.ts',
 				'src/service-worker.ts',


### PR DESCRIPTION
## Problem

A customer (`choude@gci.net`, 1072 puzzles completed) reported the app was "down." It wasn't — he'd reached a **corrupt seeded puzzle** as his newest unplayed one: an all-black 5×5 grid titled "Black Mini" with **zero clues**. The front end renders any zero-clue puzzle as an infinite loading spinner (`{#if clues.length === 0}`), so to a caught-up power user it looked exactly like an outage. Because `nextPuzzle` orders by `created_at DESC`, every caught-up user would have hit it.

Root cause: the bad puzzle came from the **crosshare seed feed** (author "unbiunium", not the generator's "xwords robot" stamp), so the guard belongs on the serving path where it protects against any bad puzzle regardless of source.

## Already done (live)

Deleted the 2 all-black/zero-clue rows from the prod DB (both had **zero** `user_puzzles` references — nobody had completed them). Verified the affected user now receives a valid puzzle. This PR prevents recurrence.

## Changes

- **`puzzle-validator.ts`** — `isValidPuzzle()` rejects undecodable, zero-clue, or all-black-solution puzzles. Handles both the AI shape (`clues.across/down`) and the legacy seed shape (`details.clues`, double-JSON-encoded).
- **`nextPuzzle` handler** — pulls the 10 newest unplayed puzzles and serves the first valid one, skipping corrupt rows. Guards web **and** iOS with no client release. Returns `null` when none are valid.
- **`getNextPuzzle.ts`** — returns `null` cleanly instead of crashing on a missing `puzJson`.
- **`Puzzle.svelte`** — shows an "you've completed every puzzle 🎉" state for the null case, and wraps `onNextPuzzle` in try/catch (it previously had none — a reject froze the screen).
- **Tests** — validator unit tests (both shapes, double-encoding, all-black, primitives) + a null-path test for `getNextPuzzle`. Wired `sql-queries` into the vitest include + coverage.

## Verification

Local gates all green: lint, typecheck, `test:coverage` (695 tests), CRAP check, build. E2E runs in CI.

## Follow-up (not in this PR)

Validate at **ingestion** in `build-puzzle-collection.ts` so corrupt puzzles never enter the table in the first place.