### PR TITLE
fix(build-puzzle-collection): reject corrupt puzzles at ingestion

### DIFF
--- a/amplify/function/build-puzzle-collection.ts
+++ b/amplify/function/build-puzzle-collection.ts
@@ -12,6 +12,7 @@ import createClues from '../../src/routes/components/crossword/helpers/createClu
 import { env } from '$amplify/env/seedPuzzleDbFunction';
 import { createPuzzle } from './graphql/mutations';
 import { listPuzzles } from './graphql/queries';
+import { isValidPuzzle } from './sql-queries/puzzle-validator';
 
 dotenv.config();
 const s3 = new S3Client();
@@ -103,6 +104,13 @@ const createDynamoRecord = async (buffer: Buffer, puzKey: string): Promise<boole
 	const clues = [...across, ...down];
 	const isValid = validateClues(createClues(clues));
 	if (!isValid) {
+		return false;
+	}
+	// validateClues passes vacuously for an empty clue set, so an all-black /
+	// clueless puzzle would otherwise slip through. isValidPuzzle rejects those
+	// (zero clues or an all-dot solution grid) — same guard the serving path uses.
+	if (!isValidPuzzle(json)) {
+		console.log({ msg: 'rejecting corrupt puzzle (no clues / all-black grid)', puzKey });
 		return false;
 	}
 	console.log({ isValid, puzKey });


### PR DESCRIPTION
## Follow-up to #38

#38 added a guard on the **serving** path so corrupt puzzles are skipped when handed to a client. This PR closes the hole one layer earlier — at **ingestion** — so they never enter the table at all.

## Why the existing check missed it

`createDynamoRecord` already calls `validateClues(createClues(clues))`, but `validateClues` only checks prop types and cell-answer consistency. For an all-black puzzle the clue set is **empty**, so every loop is a no-op and it returns `true` vacuously. That's how the "Black Mini" (all-black 5×5, zero clues) slipped into the collection.

## Change

Add the same `isValidPuzzle()` guard the serving path uses, right after `validateClues` and before the DynamoDB/SQL insert. It rejects zero-clue and all-black-solution puzzles, with a log line naming the rejected `puzKey`. Single source of truth, reused across both paths.

## Verification

Local gates green: lint, typecheck, `test:coverage` (695 tests), CRAP, build. The validator itself is already unit-tested in #38; this is a one-line reuse at the call site.