### PR TITLE
fix(backend): upgrade RDS MySQL 8.0 → 8.4 LTS to drop Extended Support fee

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -110,7 +110,12 @@ const vpc = ec2.Vpc.fromVpcAttributes(sqlStack, 'DefaultVPC', {
 });
 
 const dbInstance = new rds.DatabaseInstance(sqlStack, 'CrosswordDB', {
-	engine: rds.DatabaseInstanceEngine.mysql({ version: rds.MysqlEngineVersion.VER_8_0_39 }),
+	// MySQL 8.4 is the current LTS and is in RDS standard support. Staying on 8.0
+	// (community EOL) triggers the RDS Extended Support surcharge (~$43/mo); moving
+	// to 8.4 removes that fee. A major-version bump (8.0 -> 8.4) requires
+	// allowMajorVersionUpgrade, otherwise RDS rejects the modify.
+	engine: rds.DatabaseInstanceEngine.mysql({ version: rds.MysqlEngineVersion.VER_8_4_6 }),
+	allowMajorVersionUpgrade: true,
 	instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
 	vpc,
 	vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },


### PR DESCRIPTION
## What
Bump the crossword RDS instance from MySQL `8.0` (pinned `VER_8_0_39`, drifted to 8.0.45 via auto-minor-upgrade) to **8.4 LTS** (`VER_8_4_6`), and add `allowMajorVersionUpgrade: true`.

## Why
MySQL 8.0 hit community end-of-life, so RDS started billing **Extended Support** on this instance: **$43.20/mo** (`USW2-ExtendedSupport:Yr1-Yr2:MySQL8.0`), which more than tripled the DB's bill (~$15 → ~$47/mo in Aug 2026). MySQL **8.4 is the current LTS and is in RDS standard support**, so moving to it removes the surcharge. A minor 8.0.x bump would **not** help — the whole 8.0 major line is what's in Extended Support.

## Validation
- `8.0.45 → 8.4.x` confirmed as a valid direct `ValidUpgradeTarget` in us-west-2 via `describe-db-engine-versions`.
- `8.4.6` is offered by RDS in us-west-2 and exists as a CDK constant in aws-cdk-lib 2.234.x.
- Major-version bump requires `allowMajorVersionUpgrade`; the default parameter group family auto-moves 8.0 → 8.4.

## Deploy notes
- This is an **in-place major-version upgrade** on apply → brief downtime while RDS upgrades the engine (single-AZ `db.t3.micro`). Fine for this app; worth deploying off-peak.
- Take/verify a snapshot before the Amplify pipeline applies (backupRetention is 7 days; RDS also auto-snapshots pre-upgrade).

Followups (not in this PR): the instance is `publiclyAccessible: true` and `storageEncrypted` is off — security hardening candidates.