### PR TITLE
fix: NYT-style cursor navigation, completion integrity, and UX fixes

### DIFF
--- a/amplify/function/build-puzzle-collection.ts
+++ b/amplify/function/build-puzzle-collection.ts
@@ -313,7 +313,7 @@ export const handler = async (event: BuildPuzzleCollectionEvent) => {
 		const seedDates = dateRange(event.startDate, event.endDate, 30);
 		for (const seedDate of seedDates) {
 			const res = await handlerHelper(seedDate);
-			results.concat(res);
+			results.push(...res);
 		}
 	} else {
 		results = await handlerHelper(today);

--- a/amplify/function/sql-queries/handler.ts
+++ b/amplify/function/sql-queries/handler.ts
@@ -20,15 +20,16 @@ export const handler: Handler = async (event) => {
 
 	try {
 		if (query === 'leaderboard') {
+			// Only expose display names publicly — emails are PII and must not
+			// ship in the leaderboard payload.
 			const [rows] = await conn.execute(`
 				SELECT
 					p.id,
 					p.name,
-					p.email,
 					COUNT(up.id) as completedCount
 				FROM profiles p
 				LEFT JOIN user_puzzles up ON p.id = up.profile_id
-				GROUP BY p.id, p.name, p.email
+				GROUP BY p.id, p.name
 				ORDER BY completedCount DESC
 				LIMIT 100
 			`);

--- a/src/routes/HeaderNav.svelte
+++ b/src/routes/HeaderNav.svelte
@@ -19,7 +19,11 @@
 			<a href="/leaderboard">Leaderboard</a>
 		</li>
 		<li>
-			<button on:click={onToggleTheme} title="Toggle theme">
+			<button
+				on:click={onToggleTheme}
+				title="Toggle theme"
+				aria-label="Toggle theme (current: {theme})"
+			>
 				{getThemeIcon(theme)}
 			</button>
 		</li>
@@ -33,7 +37,7 @@
 	nav {
 		display: flex;
 		justify-content: center;
-		--background: rgba(255, 255, 255, 0.7);
+		--background: var(--color-bg-nav, rgba(255, 255, 255, 0.7));
 	}
 	svg {
 		width: 2em;

--- a/src/routes/Puzzle.svelte
+++ b/src/routes/Puzzle.svelte
@@ -37,7 +37,11 @@
 		cancelTimer = createTimer(tick, isComplete);
 	};
 
-	$: if (crosswordComplete && !isPuzzleComplete) {
+	// crosswordComplete is a child binding that stays true for one reactive
+	// flush after a new puzzle loads, so isPuzzleComplete must only reset once
+	// the child has actually re-evaluated (see onNextPuzzle) — otherwise this
+	// block records a bogus 0-second completion for the next puzzle.
+	$: if (crosswordComplete && !isPuzzleComplete && puzzleId) {
 		isPuzzleComplete = true;
 		submitPuzzleCompletion({
 			profileId: profile.id,
@@ -47,6 +51,9 @@
 			usedReveal,
 			timeInSeconds
 		});
+	}
+	$: if (!crosswordComplete && isPuzzleComplete) {
+		isPuzzleComplete = false;
 	}
 
 	onMount(() => {
@@ -88,7 +95,9 @@
 			}
 			timeInSeconds = 0;
 			usedCheck = usedReveal = usedClear = false;
-			isPuzzleComplete = false;
+			// isPuzzleComplete intentionally NOT reset here — it clears
+			// reactively once the child recomputes crosswordComplete=false
+			// for the new clues, preventing a duplicate submission.
 			clues = puzzle.clues;
 			puzzleId = puzzle.id;
 			puzzleTitle = puzzle.title || '';
@@ -109,7 +118,9 @@
 		Check back soon for more.
 	</p>
 {:else if clues.length === 0}
-	<p><SyncLoader size="60" color="palevioletred" unit="px" duration="1s" /></p>
+	<div style="margin: auto">
+		<SyncLoader size="60" color="palevioletred" unit="px" duration="1s" />
+	</div>
 {:else}
 	<PuzzleHeader email={profile.email} {puzzleTitle} {puzzleAuthor} {onSignOut} />
 	<PuzzleCrossword
@@ -118,9 +129,9 @@
 		keyboardStyle="outline"
 		{timeInSeconds}
 		{isPuzzleComplete}
-		{usedClear}
-		{usedReveal}
-		{usedCheck}
+		bind:usedClear
+		bind:usedReveal
+		bind:usedCheck
 		onToggleKeyboard={toggleKeyboard}
 		{onNextPuzzle}
 		bind:isComplete={crosswordComplete}

--- a/src/routes/Puzzle.test.ts
+++ b/src/routes/Puzzle.test.ts
@@ -84,7 +84,7 @@ describe('routes/Puzzle', () => {
 		const { container } = render(Puzzle);
 		// SyncLoader renders a wrapping element; the grid article must NOT be present yet.
 		expect(container.querySelector('article.svelte-crossword')).toBeNull();
-		expect(container.querySelector('p')).not.toBeNull();
+		expect(container.querySelector('div[style*="margin"]')).not.toBeNull();
 	});
 
 	it('calls initializePuzzle on mount', () => {

--- a/src/routes/PuzzleCrossword.svelte
+++ b/src/routes/PuzzleCrossword.svelte
@@ -28,9 +28,9 @@
 		<PuzzleToolbar
 			{timeInSeconds}
 			{isPuzzleComplete}
-			{usedClear}
-			{usedReveal}
-			{usedCheck}
+			bind:usedClear
+			bind:usedReveal
+			bind:usedCheck
 			{showAppKeyboard}
 			{onClear}
 			{onReveal}

--- a/src/routes/components/crossword/Puzzle.svelte
+++ b/src/routes/components/crossword/Puzzle.svelte
@@ -62,7 +62,8 @@
 			sortedCellsInDirection,
 			clues,
 			isPuzzleFocused,
-			numberOfStatesInHistory
+			numberOfStatesInHistory,
+			isChecking
 		};
 	}
 	function fh() {

--- a/src/routes/components/crossword/PuzzleKeyboard.test.ts
+++ b/src/routes/components/crossword/PuzzleKeyboard.test.ts
@@ -27,7 +27,7 @@ describe('PuzzleKeyboard', () => {
 		const { getByText } = render(PuzzleKeyboard, {
 			props: { onKeydown, keyboardStyle: 'outline' }
 		});
-		await fireEvent.mouseDown(getByText('A'));
+		await fireEvent.pointerDown(getByText('A'));
 		expect(onKeydown).toHaveBeenCalledOnce();
 		expect(onKeydown.mock.calls[0][0].detail).toBe('A');
 	});

--- a/src/routes/components/crossword/helpers/cellNavigation.js
+++ b/src/routes/components/crossword/helpers/cellNavigation.js
@@ -1,0 +1,49 @@
+/**
+ * Cell-level cursor movement: locked-cell rules and stepping between squares.
+ * Word/clue-level navigation lives in puzzleNavigation.js.
+ */
+
+/**
+ * A cell is locked once check mode has verified its letter as correct;
+ * locked cells are never landed on or overwritten.
+ * @param {import('./types').Cell} cell
+ * @param {boolean} [isChecking]
+ * @returns {boolean}
+ */
+export function isLockedCell(cell, isChecking) {
+	return !!isChecking && !!cell.value && cell.value === cell.answer;
+}
+
+/**
+ * Walks the grid from the focused cell, skipping filled cells when not
+ * replacing and always skipping checked-correct (locked) cells.
+ * @param {{
+ *   sortedCellsInDirection: import('./types').Cell[],
+ *   focusedCellIndex: number,
+ *   diff: number,
+ *   doReplaceFilledCells?: boolean,
+ *   isChecking?: boolean
+ * }} params
+ * @returns {number | null}
+ */
+export function getNextCellInDirection({
+	sortedCellsInDirection,
+	focusedCellIndex,
+	diff,
+	doReplaceFilledCells = true,
+	isChecking = false
+}) {
+	const isLandable = (/** @type {import('./types').Cell} */ cell) =>
+		!isLockedCell(cell, isChecking) && (doReplaceFilledCells || !cell.value);
+	const pos = sortedCellsInDirection.findIndex((d) => d.index === focusedCellIndex);
+	if (pos === -1) return null;
+	const step = diff > 0 ? 1 : -1;
+	let remaining = Math.abs(diff);
+	let i = pos;
+	while (remaining > 0) {
+		i += step;
+		if (i < 0 || i >= sortedCellsInDirection.length) return null;
+		if (isLandable(sortedCellsInDirection[i])) remaining--;
+	}
+	return sortedCellsInDirection[i].index;
+}

--- a/src/routes/components/crossword/helpers/cursorSpec.test.js
+++ b/src/routes/components/crossword/helpers/cursorSpec.test.js
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import { dispatch } from './puzzleController.js';
+import { initializeCrosswordData } from './crosswordActions.js';
+import { checkClueCompletion } from './crosswordLogic.js';
+
+/**
+ * NYT-style cursor advancement specification.
+ *
+ * These tests encode the DESIRED cursor behavior (how the New York Times
+ * crossword behaves), driven through the real engine: createClues/createCells
+ * via initializeCrosswordData, then dispatch() with the same state snapshot
+ * loop Puzzle.svelte uses.
+ *
+ * Test grid (3x3, no black squares):
+ *
+ *        x0  x1  x2
+ *   y0    C   A   T     1A CAT  (indices 0,1,2)
+ *   y1    O   R   E     4A ORE  (indices 3,4,5)
+ *   y2    P   E   N     5A PEN  (indices 6,7,8)
+ *
+ *   1D COP (0,3,6)   2D ARE (1,4,7)   3D TEN (2,5,8)
+ */
+
+/** @type {import('./types').ClueInput[]} */
+const GRID = [
+	{ answer: 'CAT', clue: 'Feline', x: 0, y: 0, direction: 'across' },
+	{ answer: 'ORE', clue: 'Mined rock', x: 0, y: 1, direction: 'across' },
+	{ answer: 'PEN', clue: 'Writing tool', x: 0, y: 2, direction: 'across' },
+	{ answer: 'COP', clue: 'Officer', x: 0, y: 0, direction: 'down' },
+	{ answer: 'ARE', clue: 'To be, plural', x: 1, y: 0, direction: 'down' },
+	{ answer: 'TEN', clue: 'Dime count', x: 2, y: 0, direction: 'down' }
+];
+
+/**
+ * Harness that mirrors the reactive loop of Puzzle.svelte + Crossword.svelte:
+ * snapshot state -> dispatch -> apply patch -> recompute derived values.
+ * @param {{ isChecking?: boolean }} [opts]
+ */
+function createHarness(opts = {}) {
+	const { clues, cells } = initializeCrosswordData(GRID);
+	const state = {
+		cells,
+		clues: checkClueCompletion(clues, cells),
+		cellsHistory: /** @type {import('./types').Cell[][]} */ ([]),
+		cellsHistoryIndex: 0,
+		focusedDirection: /** @type {import('./types').Direction} */ ('across'),
+		focusedCellIndex: 0,
+		focusedCellIndexHistory: [0],
+		focusedCellIndexHistoryIndex: 0,
+		isPuzzleFocused: true,
+		numberOfStatesInHistory: 10,
+		isChecking: !!opts.isChecking
+	};
+
+	const sorted = () =>
+		[...state.cells].sort((a, b) =>
+			state.focusedDirection === 'down' ? a.x - b.x || a.y - b.y : a.y - b.y || a.x - b.x
+		);
+
+	const snapshot = () => ({
+		...state,
+		focusedCell: state.cells[state.focusedCellIndex],
+		sortedCellsInDirection: sorted()
+	});
+
+	/** @param {import('./types').PuzzleAction} action */
+	const act = (action) => {
+		const patch = dispatch(snapshot(), action);
+		if (!patch) return;
+		Object.assign(state, patch);
+		state.clues = checkClueCompletion(state.clues, state.cells);
+	};
+
+	return {
+		state,
+		act,
+		/** Type a letter at the current cursor via the keyboard path. */
+		type: (/** @type {string} */ letter) => act({ type: 'keydown', detail: letter }),
+		backspace: () => act({ type: 'keydown', detail: 'Backspace' }),
+		/** Click a cell (first click focuses; a second click on the same cell flips direction). */
+		click: (/** @type {number} */ index) => act({ type: 'focusCell', index }),
+		arrow: (/** @type {import('./types').Direction} */ direction, /** @type {number} */ diff) =>
+			act({ type: 'moveFocus', direction, diff }),
+		/** Pre-fill cells as if loaded/typed earlier, without moving the cursor. */
+		fill: (/** @type {Record<number, string>} */ values) => {
+			state.cells = state.cells.map((c) =>
+				values[c.index] !== undefined ? { ...c, value: values[c.index] } : c
+			);
+			state.clues = checkClueCompletion(state.clues, state.cells);
+		},
+		focus: (/** @type {number} */ index, /** @type {import('./types').Direction} */ dir) => {
+			state.focusedCellIndex = index;
+			if (dir) state.focusedDirection = dir;
+		},
+		get cursor() {
+			return state.focusedCellIndex;
+		},
+		get direction() {
+			return state.focusedDirection;
+		},
+		valueAt: (/** @type {number} */ index) => state.cells[index].value
+	};
+}
+
+describe('cursor: typing within a word', () => {
+	it('advances to the next empty cell when the word is empty', () => {
+		const h = createHarness();
+		h.type('C');
+		expect(h.valueAt(0)).toBe('C');
+		expect(h.cursor).toBe(1);
+		expect(h.direction).toBe('across');
+	});
+
+	it('skips over an already-filled letter to the next empty square', () => {
+		const h = createHarness();
+		h.fill({ 1: 'A' }); // C _A_ T -> middle already filled
+		h.focus(0, 'across');
+		h.type('C');
+		expect(h.cursor).toBe(2); // skips index 1, lands on the empty T square
+	});
+
+	it('typing over a filled letter advances to the next EMPTY square, not the next filled one', () => {
+		const h = createHarness();
+		h.fill({ 0: 'X', 1: 'A' }); // wrong letter at 0, correct at 1, empty at 2
+		h.focus(0, 'across');
+		h.type('C'); // fix the first letter
+		expect(h.valueAt(0)).toBe('C');
+		expect(h.cursor).toBe(2); // NYT skips the filled A and lands on the empty square
+	});
+
+	it('typing into the last empty square of a word jumps to the next incomplete word', () => {
+		const h = createHarness();
+		h.fill({ 0: 'C', 2: 'T' }); // only the middle of 1A is empty
+		h.focus(1, 'across');
+		h.type('A');
+		expect(h.cursor).toBe(3); // first cell of 4A ORE
+		expect(h.direction).toBe('across');
+	});
+
+	it('lands on the first EMPTY square of the next word, not its first square', () => {
+		const h = createHarness();
+		h.fill({ 0: 'C', 1: 'A', 3: 'O' }); // 1A missing only T; 4A already has its first letter
+		h.focus(2, 'across');
+		h.type('T');
+		expect(h.cursor).toBe(4); // 4A's first empty square, skipping the pre-filled O
+	});
+
+	it('skips fully-completed words when jumping to the next word', () => {
+		const h = createHarness();
+		h.fill({ 0: 'C', 1: 'A', 3: 'O', 4: 'R', 5: 'E' }); // 4A completely done
+		h.focus(2, 'across');
+		h.type('T'); // completes 1A
+		expect(h.cursor).toBe(6); // jumps past 4A to 5A PEN
+	});
+});
+
+describe('cursor: word-to-word and direction transitions', () => {
+	it('completing the last across word jumps to the first incomplete DOWN word', () => {
+		const h = createHarness();
+		// Everything filled except 4A's middle (index 4) and 5A's last (index 8).
+		// 1D COP is complete via crossings; 2D ARE is incomplete (missing index 4);
+		// 3D TEN is incomplete (missing index 8).
+		h.fill({ 0: 'C', 1: 'A', 2: 'T', 3: 'O', 5: 'E', 6: 'P', 7: 'E' });
+		h.focus(8, 'across');
+		h.type('N'); // completes 5A, the last across word; 3D also completes
+		// Only incomplete word left is 2D ARE. NYT jumps there, onto its empty square.
+		expect(h.direction).toBe('down');
+		expect(h.cursor).toBe(4);
+	});
+
+	it('when jumping into the other direction, lands on the first empty cell of that word', () => {
+		const h = createHarness();
+		// Everything filled except 2D's middle square (index 4).
+		h.fill({ 0: 'C', 1: 'A', 2: 'T', 3: 'O', 5: 'E', 6: 'P', 7: 'E', 8: 'N' });
+		h.focus(6, 'across'); // on the last across clue (5A, already complete)
+		h.act({ type: 'focusClueDiff', diff: 1 }); // "next clue" wraps into down
+		// Only incomplete word anywhere is 2D ARE (missing index 4).
+		expect(h.direction).toBe('down');
+		expect(h.cursor).toBe(4);
+	});
+
+	it('clicking the focused cell flips direction', () => {
+		const h = createHarness();
+		h.click(0);
+		expect(h.direction).toBe('down');
+		h.click(0);
+		expect(h.direction).toBe('across');
+	});
+
+	it('arrow key in the cross direction flips direction without moving', () => {
+		const h = createHarness();
+		h.focus(0, 'across');
+		h.arrow('down', 1);
+		expect(h.direction).toBe('down');
+		expect(h.cursor).toBe(0);
+	});
+
+	it('arrow key in the focused direction moves one cell', () => {
+		const h = createHarness();
+		h.focus(0, 'across');
+		h.arrow('across', 1);
+		expect(h.cursor).toBe(1);
+	});
+});
+
+describe('cursor: backspace', () => {
+	it('backspace on a filled square clears it and keeps the cursor there', () => {
+		const h = createHarness();
+		h.fill({ 0: 'C', 1: 'A' });
+		h.focus(1, 'across');
+		h.backspace();
+		expect(h.valueAt(1)).toBe('');
+		expect(h.cursor).toBe(1);
+	});
+
+	it('backspace on an empty square moves back and clears the previous letter', () => {
+		const h = createHarness();
+		h.fill({ 0: 'C' });
+		h.focus(1, 'across');
+		h.backspace();
+		expect(h.cursor).toBe(0);
+		expect(h.valueAt(0)).toBe('');
+	});
+
+	it('backspace at the first square of the grid does not move or throw', () => {
+		const h = createHarness();
+		h.focus(0, 'across');
+		h.backspace();
+		expect(h.cursor).toBe(0);
+	});
+});
+
+describe('cursor: check mode locks verified-correct letters', () => {
+	// Once "check" has verified a letter as correct it is locked: typing
+	// advance skips it, typing on it does not overwrite it, and backspace
+	// does not clear it.
+	it('typing skips over checked-correct letters to the next empty square', () => {
+		const h = createHarness({ isChecking: true });
+		h.fill({ 0: 'X', 1: 'A' }); // 0 wrong, 1 verified correct, 2 empty
+		h.focus(0, 'across');
+		h.type('C');
+		expect(h.cursor).toBe(2); // must skip the locked A
+	});
+
+	it('typing on a checked-correct letter does not overwrite it', () => {
+		const h = createHarness({ isChecking: true });
+		h.fill({ 1: 'A' }); // verified correct
+		h.focus(1, 'across');
+		h.type('X');
+		expect(h.valueAt(1)).toBe('A');
+	});
+
+	it('backspace does not clear a checked-correct letter', () => {
+		const h = createHarness({ isChecking: true });
+		h.fill({ 1: 'A' }); // verified correct
+		h.focus(1, 'across');
+		h.backspace();
+		expect(h.valueAt(1)).toBe('A');
+	});
+});

--- a/src/routes/components/crossword/helpers/puzzleCellUpdate.js
+++ b/src/routes/components/crossword/helpers/puzzleCellUpdate.js
@@ -1,3 +1,5 @@
+import { isLockedCell } from './puzzleNavigation.js';
+
 const NUMBER_OF_STATES_IN_HISTORY = 10;
 
 /**
@@ -13,7 +15,8 @@ const NUMBER_OF_STATES_IN_HISTORY = 10;
  *   index: number,
  *   newValue: string,
  *   diff?: number,
- *   doReplaceFilledCells?: boolean
+ *   doReplaceFilledCells?: boolean,
+ *   isChecking?: boolean
  * }} params
  */
 export function processCellUpdate({
@@ -24,10 +27,9 @@ export function processCellUpdate({
 	index,
 	newValue,
 	diff = 1,
-	doReplaceFilledCells = false
+	doReplaceFilledCells = false,
+	isChecking = false
 }) {
-	doReplaceFilledCells = doReplaceFilledCells || !!cells[index].value;
-
 	const dimension = focusedDirection === 'across' ? 'x' : 'y';
 	const clueIndex = cells[index].clueNumbers[focusedDirection];
 	const allCellsInClue = cells.filter((cell) => cell.clueNumbers[focusedDirection] === clueIndex);
@@ -41,11 +43,15 @@ export function processCellUpdate({
 		.filter(/** @returns {n is number} */ (n) => Number.isFinite(n));
 	const isAtEndOfClue = cells[index][dimension] === Math.max(...cellsInCluePositions);
 
-	const newCells = [
-		...cells.slice(0, index),
-		{ ...cells[index], value: newValue.toUpperCase() },
-		...cells.slice(index + 1)
-	];
+	// Checked-correct letters are locked: keep the value and only navigate.
+	const isLocked = isLockedCell(cells[index], isChecking);
+	const newCells = isLocked
+		? cells
+		: [
+				...cells.slice(0, index),
+				{ ...cells[index], value: newValue.toUpperCase() },
+				...cells.slice(index + 1)
+			];
 	const newHistory = [newCells, ...cellsHistory.slice(cellsHistoryIndex)].slice(
 		0,
 		NUMBER_OF_STATES_IN_HISTORY
@@ -81,19 +87,4 @@ export function classifyKey(key, ctrlKey = false, altKey = false) {
 		return { type: 'letter', value: key.toUpperCase() };
 	}
 	return null;
-}
-
-/**
- * Process a virtual keyboard event detail into update parameters.
- * Returns { value, diff, doReplaceFilledCells }
- * @param {string} detail
- * @returns {{ value: string, diff: number, doReplaceFilledCells: boolean }}
- */
-export function processKeyboardEvent(detail) {
-	const isBackspace = detail === 'Backspace';
-	return {
-		value: isBackspace ? '' : detail,
-		diff: isBackspace ? -1 : 1,
-		doReplaceFilledCells: isBackspace
-	};
 }

--- a/src/routes/components/crossword/helpers/puzzleCellUpdate.test.js
+++ b/src/routes/components/crossword/helpers/puzzleCellUpdate.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { processCellUpdate, classifyKey, processKeyboardEvent } from './puzzleCellUpdate.js';
+import { processCellUpdate, classifyKey } from './puzzleCellUpdate.js';
 
 describe('processCellUpdate', () => {
 	/** @type {import('./types').Cell[]} */
@@ -118,17 +118,5 @@ describe('classifyKey', () => {
 	it('handles parentheses as valid keys', () => {
 		expect(classifyKey('(')).toEqual({ type: 'letter', value: '(' });
 		expect(classifyKey(')')).toEqual({ type: 'letter', value: ')' });
-	});
-});
-
-describe('processKeyboardEvent', () => {
-	it('handles Backspace', () => {
-		const result = processKeyboardEvent('Backspace');
-		expect(result).toEqual({ value: '', diff: -1, doReplaceFilledCells: true });
-	});
-
-	it('handles letter input', () => {
-		const result = processKeyboardEvent('A');
-		expect(result).toEqual({ value: 'A', diff: 1, doReplaceFilledCells: false });
 	});
 });

--- a/src/routes/components/crossword/helpers/puzzleController.js
+++ b/src/routes/components/crossword/helpers/puzzleController.js
@@ -1,4 +1,5 @@
-import { processCellUpdate, classifyKey, processKeyboardEvent } from './puzzleCellUpdate.js';
+import { processCellUpdate, classifyKey } from './puzzleCellUpdate.js';
+import { getNextCellInDirection, isLockedCell } from './puzzleNavigation.js';
 import {
 	resolveFocusCellDiff,
 	resolveFocusClueDiff,
@@ -26,7 +27,8 @@ function handleCellUpdate(state, index, value, diff, doReplace) {
 		index,
 		newValue: value,
 		diff,
-		doReplaceFilledCells: doReplace
+		doReplaceFilledCells: doReplace,
+		isChecking: state.isChecking
 	});
 	const patch = {
 		cells: r.cells,
@@ -43,13 +45,36 @@ function handleCellUpdate(state, index, value, diff, doReplace) {
 }
 
 /**
+ * NYT backspace semantics: clear the focused square in place if it holds an
+ * (unlocked) letter; otherwise step back one square and clear that one.
+ * @param {import('./types').PuzzleState} state
+ * @returns {import('./types').StatePatch}
+ */
+function handleDelete(state) {
+	const current = state.cells[state.focusedCellIndex];
+	if (current.value && !isLockedCell(current, state.isChecking)) {
+		return handleCellUpdate(state, state.focusedCellIndex, '', 0, true);
+	}
+	const prev = getNextCellInDirection({
+		sortedCellsInDirection: state.sortedCellsInDirection,
+		focusedCellIndex: state.focusedCellIndex,
+		diff: -1,
+		doReplaceFilledCells: true,
+		isChecking: state.isChecking
+	});
+	if (prev == null) return {};
+	const moved = { ...state, focusedCellIndex: prev, focusedCell: state.cells[prev] };
+	return handleCellUpdate(moved, prev, '', 0, true);
+}
+
+/**
  * @param {import('./types').PuzzleState} state
  * @param {string} detail
  * @returns {import('./types').StatePatch}
  */
 function handleKeydown(state, detail) {
-	const { value, diff, doReplaceFilledCells } = processKeyboardEvent(detail);
-	return handleCellUpdate(state, state.focusedCellIndex, value, diff, doReplaceFilledCells);
+	if (detail === 'Backspace') return handleDelete(state);
+	return handleCellUpdate(state, state.focusedCellIndex, detail, 1, false);
 }
 
 /**
@@ -60,9 +85,8 @@ function handleKeydown(state, detail) {
 function handleNativeKeydown(state, action) {
 	const a = classifyKey(action.key, action.ctrlKey, action.altKey);
 	if (!a) return null;
-	const value = a.type === 'delete' ? '' : a.value;
-	const diff = a.type === 'delete' ? -1 : 1;
-	return handleCellUpdate(state, state.focusedCellIndex, value, diff, a.type === 'delete');
+	if (a.type === 'delete') return handleDelete(state);
+	return handleCellUpdate(state, state.focusedCellIndex, a.value, 1, false);
 }
 
 /**

--- a/src/routes/components/crossword/helpers/puzzleNavigation.js
+++ b/src/routes/components/crossword/helpers/puzzleNavigation.js
@@ -1,25 +1,8 @@
 import getCellAfterDiff from './getCellAfterDiff.js';
 
-/**
- * @param {{
- *   sortedCellsInDirection: import('./types').Cell[],
- *   focusedCellIndex: number,
- *   diff: number,
- *   doReplaceFilledCells?: boolean
- * }} params
- * @returns {number | null}
- */
-export function getNextCellInDirection({
-	sortedCellsInDirection,
-	focusedCellIndex,
-	diff,
-	doReplaceFilledCells = true
-}) {
-	const filtered = sortedCellsInDirection.filter((d) => (doReplaceFilledCells ? true : !d.value));
-	const currentIdx = filtered.findIndex((d) => d.index === focusedCellIndex);
-	const nextCell = filtered[currentIdx + diff];
-	return nextCell ? nextCell.index : null;
-}
+// Cell-level stepping lives in cellNavigation.js; re-exported here so
+// existing imports keep working.
+export { isLockedCell, getNextCellInDirection } from './cellNavigation.js';
 
 /**
  * @param {import('./types').Clue[]} clues
@@ -53,8 +36,10 @@ function findCandidateClues(clues, focusedDirection, currentNumber, allFilled, d
 function resolveNextClue(candidates, diff, clues, focusedDirection) {
 	const nextClue = candidates[Math.abs(diff) - 1];
 	if (nextClue) return { clue: nextClue, direction: focusedDirection };
+	// Wrap into the other direction, preferring its first incomplete clue.
 	const newDirection = focusedDirection === 'across' ? 'down' : 'across';
-	return { clue: clues.filter((c) => c.direction === newDirection)[0], direction: newDirection };
+	const wrapped = clues.filter((c) => c.direction === newDirection);
+	return { clue: wrapped.find((c) => !c.isFilled) || wrapped[0], direction: newDirection };
 }
 
 /**
@@ -101,13 +86,16 @@ export function getNextClueCell({
 		clues,
 		focusedDirection
 	);
+	// Resolve the landing cell against the direction the clue belongs to (it
+	// may differ from focusedDirection after wrapping across<->down). After a
+	// wrap, allFilled described the old direction, so prefer empty cells.
 	const nextCell = findCellForClue(
 		sortedCellsInDirection,
 		nextClue?.number,
-		focusedDirection,
-		allFilled
+		newDirection,
+		allFilled && newDirection === focusedDirection
 	);
-	return { focusedCellIndex: nextCell.index || 0, focusedDirection: newDirection };
+	return { focusedCellIndex: nextCell.index ?? 0, focusedDirection: newDirection };
 }
 
 /**

--- a/src/routes/components/crossword/helpers/puzzleNavigation.test.js
+++ b/src/routes/components/crossword/helpers/puzzleNavigation.test.js
@@ -54,6 +54,66 @@ describe('getNextCellInDirection', () => {
 		});
 		expect(result).toBeNull();
 	});
+
+	it('returns null when the focused cell is not in the sorted list', () => {
+		const result = getNextCellInDirection({
+			sortedCellsInDirection: sorted,
+			focusedCellIndex: 99,
+			diff: 1
+		});
+		expect(result).toBeNull();
+	});
+
+	it('skips checked-correct (locked) cells when isChecking is true', () => {
+		/** @type {import('./types').Cell[]} */
+		const cells = /** @type {any} */ ([
+			{ index: 0, value: '', answer: 'A' },
+			{ index: 1, value: 'B', answer: 'B' }, // locked: correct while checking
+			{ index: 2, value: '', answer: 'C' }
+		]);
+		const result = getNextCellInDirection({
+			sortedCellsInDirection: cells,
+			focusedCellIndex: 0,
+			diff: 1,
+			doReplaceFilledCells: true,
+			isChecking: true
+		});
+		expect(result).toBe(2);
+	});
+
+	it('does not skip incorrect letters when isChecking is true', () => {
+		/** @type {import('./types').Cell[]} */
+		const cells = /** @type {any} */ ([
+			{ index: 0, value: '', answer: 'A' },
+			{ index: 1, value: 'X', answer: 'B' }, // wrong: still landable
+			{ index: 2, value: '', answer: 'C' }
+		]);
+		const result = getNextCellInDirection({
+			sortedCellsInDirection: cells,
+			focusedCellIndex: 0,
+			diff: 1,
+			doReplaceFilledCells: true,
+			isChecking: true
+		});
+		expect(result).toBe(1);
+	});
+
+	it('moves backward past locked cells', () => {
+		/** @type {import('./types').Cell[]} */
+		const cells = /** @type {any} */ ([
+			{ index: 0, value: '', answer: 'A' },
+			{ index: 1, value: 'B', answer: 'B' },
+			{ index: 2, value: '', answer: 'C' }
+		]);
+		const result = getNextCellInDirection({
+			sortedCellsInDirection: cells,
+			focusedCellIndex: 2,
+			diff: -1,
+			doReplaceFilledCells: true,
+			isChecking: true
+		});
+		expect(result).toBe(0);
+	});
 });
 
 describe('getFlippedDirection', () => {

--- a/src/routes/components/crossword/helpers/puzzleStateResolvers.js
+++ b/src/routes/components/crossword/helpers/puzzleStateResolvers.js
@@ -17,7 +17,8 @@ export function resolveFocusCellDiff(state, diff, doReplace) {
 		sortedCellsInDirection: state.sortedCellsInDirection,
 		focusedCellIndex: state.focusedCellIndex,
 		diff,
-		doReplaceFilledCells: doReplace
+		doReplaceFilledCells: doReplace,
+		isChecking: state.isChecking
 	});
 	if (i != null) return resolveFocusCell(state, i, false, state.numberOfStatesInHistory);
 	return null;

--- a/src/routes/components/crossword/helpers/types.ts
+++ b/src/routes/components/crossword/helpers/types.ts
@@ -70,6 +70,8 @@ export interface PuzzleState {
 	clues: Clue[];
 	isPuzzleFocused: boolean;
 	numberOfStatesInHistory: number;
+	/** True while check mode is on; checked-correct cells are then locked. */
+	isChecking?: boolean;
 }
 
 /** A partial state patch returned by an action resolver. */

--- a/src/routes/components/keyboard/Key.svelte
+++ b/src/routes/components/keyboard/Key.svelte
@@ -12,10 +12,9 @@
 	class="key key--{value} {keyClass}"
 	class:single={value.length === 1}
 	class:active
-	on:touchstart={(e) => onKeyStart(e, value)}
-	on:mousedown={(e) => onKeyStart(e, value)}
-	on:touchend={() => onKeyEnd(value)}
-	on:mouseup={() => onKeyEnd(value)}
+	on:pointerdown={(e) => onKeyStart(e, value)}
+	on:pointerup={() => onKeyEnd(value)}
+	on:pointercancel={() => onKeyEnd(value)}
 >
 	{#if display.includes('<svg')}{@html display}{:else}{display}{/if}
 </button>

--- a/src/routes/components/keyboard/Key.test.ts
+++ b/src/routes/components/keyboard/Key.test.ts
@@ -30,14 +30,25 @@ describe('Key', () => {
 		expect(getByRole('button')).toHaveClass('active');
 	});
 
-	it('calls onKeyStart on mousedown and onKeyEnd on mouseup', async () => {
+	it('calls onKeyStart on pointerdown and onKeyEnd on pointerup', async () => {
 		const onKeyStart = vi.fn();
 		const onKeyEnd = vi.fn();
 		const { getByRole } = render(Key, { props: { ...base, onKeyStart, onKeyEnd } });
 		const button = getByRole('button');
-		await fireEvent.mouseDown(button);
-		await fireEvent.mouseUp(button);
+		await fireEvent.pointerDown(button);
+		await fireEvent.pointerUp(button);
 		expect(onKeyStart).toHaveBeenCalledWith(expect.anything(), 'A');
 		expect(onKeyEnd).toHaveBeenCalledWith('A');
+	});
+
+	it('fires onKeyStart exactly once per pointer tap (no touch/mouse double-fire)', async () => {
+		const onKeyStart = vi.fn();
+		const { getByRole } = render(Key, { props: { ...base, onKeyStart } });
+		const button = getByRole('button');
+		// A touch tap dispatches pointerdown; compat mousedown must be ignored.
+		await fireEvent.pointerDown(button);
+		await fireEvent.mouseDown(button);
+		await fireEvent.touchStart(button);
+		expect(onKeyStart).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/routes/components/keyboard/Keyboard.test.ts
+++ b/src/routes/components/keyboard/Keyboard.test.ts
@@ -27,7 +27,7 @@ describe('Keyboard', () => {
 		const { getByText } = render(Keyboard, {
 			events: { keydown: (e: CustomEvent) => spy(e.detail) }
 		});
-		await fireEvent.mouseDown(getByText('A'));
+		await fireEvent.pointerDown(getByText('A'));
 		expect(spy).toHaveBeenCalledWith('A');
 	});
 
@@ -40,7 +40,7 @@ describe('Keyboard', () => {
 		// The number key lives on the (initially hidden) second page.
 		expect(pages()[1].contains(getByText('1'))).toBe(true);
 		// The toggle key has value "Page1"; its display is swapped to "?123".
-		await fireEvent.mouseDown(getByText('?123'));
+		await fireEvent.pointerDown(getByText('?123'));
 		// After toggling, the symbols/numbers page becomes visible.
 		expect(pages()[0]).not.toHaveClass('visible');
 		expect(pages()[1]).toHaveClass('visible');
@@ -51,7 +51,7 @@ describe('Keyboard', () => {
 		const { getByText } = render(Keyboard, {
 			events: { keydown: (e: CustomEvent) => spy(e.detail) }
 		});
-		await fireEvent.mouseDown(getByText('?123'));
+		await fireEvent.pointerDown(getByText('?123'));
 		expect(spy).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/helpers/sql/getLeaderboard.ts
+++ b/src/routes/helpers/sql/getLeaderboard.ts
@@ -3,7 +3,6 @@ import { invokeSqlQuery } from './invokeSqlQuery';
 export type LeaderboardEntry = {
 	id: string;
 	name: string;
-	email: string;
 	completedCount: number;
 };
 

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -53,7 +53,9 @@
 </script>
 
 {#if isLoading}
-	<p style="margin: auto"><SyncLoader size="60" color="palevioletred" unit="px" duration="1s" /></p>
+	<div style="margin: auto">
+		<SyncLoader size="60" color="palevioletred" unit="px" duration="1s" />
+	</div>
 {:else if completedPuzzles.length === 0}
 	<p>
 		You have not completed any puzzles.

--- a/src/routes/history/helpers/getHumanReadableDate.test.ts
+++ b/src/routes/history/helpers/getHumanReadableDate.test.ts
@@ -29,6 +29,6 @@ describe('getHumanReadableDate', () => {
 	it('formats midnight correctly', () => {
 		const date = new Date('2024-03-15T00:00:00');
 		const result = getHumanReadableDate(date);
-		expect(result).toBe('Fri Mar 15 2024 at 0:00am');
+		expect(result).toBe('Fri Mar 15 2024 at 12:00am');
 	});
 });

--- a/src/routes/history/helpers/getHumanReadableDate.ts
+++ b/src/routes/history/helpers/getHumanReadableDate.ts
@@ -1,6 +1,6 @@
 export const getHumanReadableDate = (date: Date): string => {
 	const timeSuffix = date.getHours() < 12 ? 'am' : 'pm';
-	const hours = date.getHours() > 12 ? date.getHours() - 12 : date.getHours();
+	const hours = date.getHours() % 12 || 12;
 	const minutes = date.getMinutes() < 10 ? `0${date.getMinutes()}` : date.getMinutes();
 	return `${date.toDateString()} at ${hours}:${minutes}${timeSuffix}`;
 };

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -36,9 +36,9 @@
 <div class="text-column">
 	<h1>Leaderboard</h1>
 	{#if isLoading}
-		<p style="margin: auto">
+		<div style="margin: auto">
 			<SyncLoader size="60" color="palevioletred" unit="px" duration="1s" />
-		</p>
+		</div>
 	{:else}
 		<ol>
 			{#each profiles ?? [] as profile, i}

--- a/src/routes/login/ForgotPasswordForm.svelte
+++ b/src/routes/login/ForgotPasswordForm.svelte
@@ -11,25 +11,33 @@
 </script>
 
 <h1>Reset Password</h1>
-<form id="forgotPasswordForm">
+<form
+	id="forgotPasswordForm"
+	on:submit|preventDefault={() => tryOrAlert(confirmForgotPassword ? onConfirmReset : onSendReset)}
+>
 	<label for="email">Email&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
-	<input required type="email" id="email" bind:value={username} />
+	<input required type="email" id="email" autocomplete="email" bind:value={username} />
 	<hr />
 
 	{#if !confirmForgotPassword}
-		<button type="submit" on:click={() => tryOrAlert(onSendReset)}>Send Reset Email</button>
+		<button type="submit">Send Reset Email</button>
 	{/if}
 	{#if confirmForgotPassword}
 		<p>A confirmation code was sent to your email.</p>
 		<hr />
 		<label for="confirmation">Confirmation Code</label>
-		<input required type="confirmation" id="confirmation" bind:value={confirmationCode} />
+		<input required type="text" id="confirmation" bind:value={confirmationCode} />
 		<hr />
 		<label for="password">New Password&nbsp;&nbsp;</label>
-		<input required type="password" id="password" bind:value={password} />
+		<input
+			required
+			type="password"
+			id="password"
+			autocomplete="new-password"
+			bind:value={password}
+		/>
 		<hr />
-		<button type="submit" on:click={() => tryOrAlert(onConfirmReset)}>Confirm Password Reset</button
-		>
+		<button type="submit">Confirm Password Reset</button>
 	{/if}
 </form>
 <p style="text-align: center;">

--- a/src/routes/login/ForgotPasswordForm.test.ts
+++ b/src/routes/login/ForgotPasswordForm.test.ts
@@ -50,17 +50,17 @@ describe('ForgotPasswordForm', () => {
 		expect(container.querySelector('#password')).toBeTruthy();
 	});
 
-	it('calls onSendReset (via tryOrAlert) when the Send Reset Email button is clicked', async () => {
+	it('calls onSendReset (via tryOrAlert) when the form is submitted', async () => {
 		const props = baseProps({ confirmForgotPassword: false });
-		const { getByText } = render(ForgotPasswordForm, { props });
-		await fireEvent.click(getByText('Send Reset Email'));
+		const { container } = render(ForgotPasswordForm, { props });
+		await fireEvent.submit(container.querySelector('form')!);
 		expect(props.onSendReset).toHaveBeenCalledTimes(1);
 	});
 
-	it('calls onConfirmReset (via tryOrAlert) when the Confirm Password Reset button is clicked', async () => {
+	it('calls onConfirmReset (via tryOrAlert) when submitted in confirm mode', async () => {
 		const props = baseProps({ confirmForgotPassword: true });
-		const { getByText } = render(ForgotPasswordForm, { props });
-		await fireEvent.click(getByText('Confirm Password Reset'));
+		const { container } = render(ForgotPasswordForm, { props });
+		await fireEvent.submit(container.querySelector('form')!);
 		expect(props.onConfirmReset).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/routes/login/SignInForm.svelte
+++ b/src/routes/login/SignInForm.svelte
@@ -27,15 +27,21 @@
 		<hr style="margin-inline: 0px;" />
 	</div>
 {/if}
-<form id="loginForm">
+<form id="loginForm" on:submit|preventDefault={() => tryOrAlert(onLogin)}>
 	<label for="email">Email&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
-	<input required type="email" id="email" bind:value={username} />
+	<input required type="email" id="email" autocomplete="email" bind:value={username} />
 	<br /><br />
 	<label for="password">Password&nbsp;&nbsp;</label>
-	<input required type="password" id="password" bind:value={password} />
+	<input
+		required
+		type="password"
+		id="password"
+		autocomplete="current-password"
+		bind:value={password}
+	/>
 	<button type="button" class="link-button" on:click={onShowForgotPassword}>forgot?</button>
 	<hr />
-	<button type="submit" on:click={() => tryOrAlert(onLogin)}>Log in</button>
+	<button type="submit">Log in</button>
 </form>
 <p style="text-align: center;">
 	Not registered? <a

--- a/src/routes/login/SignInForm.test.ts
+++ b/src/routes/login/SignInForm.test.ts
@@ -68,10 +68,10 @@ describe('SignInForm', () => {
 		expect(props.onLoginWithGoogle).toHaveBeenCalledTimes(1);
 	});
 
-	it('calls onLogin (via tryOrAlert) when the Log in button is clicked', async () => {
+	it('calls onLogin (via tryOrAlert) when the form is submitted', async () => {
 		const props = baseProps();
-		const { getByText } = render(SignInForm, { props });
-		await fireEvent.click(getByText('Log in'));
+		const { container } = render(SignInForm, { props });
+		await fireEvent.submit(container.querySelector('form')!);
 		expect(props.onLogin).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/routes/login/SignUpForm.svelte
+++ b/src/routes/login/SignUpForm.svelte
@@ -29,22 +29,25 @@
 		<hr style="margin-inline: 0px;" />
 	</div>
 {/if}
-<form id="registrationForm">
+<form
+	id="registrationForm"
+	on:submit|preventDefault={() => tryOrAlert(confirm ? onConfirm : onRegister)}
+>
 	<label for="email">Email&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
-	<input required type="email" id="email" bind:value={username} />
+	<input required type="email" id="email" autocomplete="email" bind:value={username} />
 	<br /><br />
 	<label for="password">Password&nbsp;&nbsp;</label>
-	<input required type="password" id="password" bind:value={password} />
+	<input required type="password" id="password" autocomplete="new-password" bind:value={password} />
 	{#if !confirm}
 		<hr />
-		<button type="submit" on:click={() => tryOrAlert(onRegister)}>Create account</button>
+		<button type="submit">Create account</button>
 	{/if}
 	{#if confirm}
 		<hr />
 		<label for="confirmation">Confirmation Code</label>
-		<input required type="confirmation" id="confirmation" bind:value={confirmationCode} />
+		<input required type="text" id="confirmation" bind:value={confirmationCode} />
 		<hr />
-		<button type="submit" on:click={() => tryOrAlert(onConfirm)}>Confirm Email</button>
+		<button type="submit">Confirm Email</button>
 	{/if}
 </form>
 <p style="text-align: center;">

--- a/src/routes/login/SignUpForm.test.ts
+++ b/src/routes/login/SignUpForm.test.ts
@@ -88,17 +88,17 @@ describe('SignUpForm', () => {
 		expect(props.onLoginWithGoogle).toHaveBeenCalledTimes(1);
 	});
 
-	it('calls onRegister (via tryOrAlert) when the Create account button is clicked', async () => {
+	it('calls onRegister (via tryOrAlert) when the form is submitted', async () => {
 		const props = baseProps({ confirm: false });
-		const { getByText } = render(SignUpForm, { props });
-		await fireEvent.click(getByText('Create account'));
+		const { container } = render(SignUpForm, { props });
+		await fireEvent.submit(container.querySelector('form')!);
 		expect(props.onRegister).toHaveBeenCalledTimes(1);
 	});
 
-	it('calls onConfirm (via tryOrAlert) when the Confirm Email button is clicked', async () => {
+	it('calls onConfirm (via tryOrAlert) when submitted in confirm mode', async () => {
 		const props = baseProps({ confirm: true });
-		const { getByText } = render(SignUpForm, { props });
-		await fireEvent.click(getByText('Confirm Email'));
+		const { container } = render(SignUpForm, { props });
+		await fireEvent.submit(container.querySelector('form')!);
 		expect(props.onConfirm).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/routes/preview/PuzzlePreview.svelte
+++ b/src/routes/preview/PuzzlePreview.svelte
@@ -2,7 +2,7 @@
 	import { SyncLoader } from 'svelte-loading-spinners';
 	import { goto } from '$app/navigation';
 	import { getCurrentUser } from 'aws-amplify/auth';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import type { Clue } from '../helpers/types/types';
 	import { previewClues } from './previewClues';
 	import { vibrate } from '../helpers/haptics';
@@ -46,7 +46,7 @@
 		isPuzzleComplete = true;
 	};
 
-	createPuzzleTimer({
+	const cancelTimer = createPuzzleTimer({
 		getRef: () => ref,
 		isPuzzleComplete: () => isPuzzleComplete,
 		onComplete: () => onPuzzleComplete(),
@@ -54,6 +54,7 @@
 			timeInSeconds++;
 		}
 	});
+	onDestroy(cancelTimer);
 
 	const toggleKeyboard = () => {
 		showAppKeyboard = toggleKeyboardSetting(showAppKeyboard);
@@ -61,7 +62,9 @@
 </script>
 
 {#if clues.length === 0}
-	<p><SyncLoader size="60" color="palevioletred" unit="px" duration="1s" /></p>
+	<div style="margin: auto">
+		<SyncLoader size="60" color="palevioletred" unit="px" duration="1s" />
+	</div>
 {:else}
 	<h3>You're not signed in!</h3>
 	<button id="signInButton" class="active" on:click={() => goto('/login')}>sign in/up</button>

--- a/src/routes/preview/PuzzlePreview.test.ts
+++ b/src/routes/preview/PuzzlePreview.test.ts
@@ -44,8 +44,10 @@ describe('preview/PuzzlePreview', () => {
 
 	it('shows the SyncLoader spinner before clues load', () => {
 		const { container } = render(PuzzlePreview);
-		// no clues yet -> the loading paragraph, no "not signed in" heading.
-		expect(container.querySelector('p')).not.toBeNull();
+		// no clues yet -> the loading spinner, no "not signed in" heading.
+		expect(
+			container.querySelector('.sync-loader, [class*="loader"], div[style*="margin"]')
+		).not.toBeNull();
 		expect(container.querySelector('article.svelte-crossword')).toBeNull();
 	});
 

--- a/src/routes/preview/helpers/puzzleTimer.test.ts
+++ b/src/routes/preview/helpers/puzzleTimer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createPuzzleTimer } from './puzzleTimer';
+import { createPuzzleTimer, findCellsInRef, resolveTimerStep } from './puzzleTimer';
 
 describe('createPuzzleTimer', () => {
 	beforeEach(() => {
@@ -86,5 +86,71 @@ describe('createPuzzleTimer', () => {
 		vi.advanceTimersByTime(1000);
 		expect(onComplete).not.toHaveBeenCalled();
 		expect(onTick).toHaveBeenCalled();
+	});
+
+	it('keeps waiting (no tick) while the ref has no cells yet', () => {
+		const onTick = vi.fn();
+		createPuzzleTimer({
+			getRef: () => ({ $$: { ctx: ['not-cells', 42] } }),
+			isPuzzleComplete: () => false,
+			onComplete: vi.fn(),
+			onTick
+		});
+		vi.advanceTimersByTime(3000);
+		expect(onTick).not.toHaveBeenCalled();
+	});
+
+	it('stops ticking after the returned cancel function is called', () => {
+		const onTick = vi.fn();
+		const cancel = createPuzzleTimer({
+			getRef: () => null,
+			isPuzzleComplete: () => false,
+			onComplete: vi.fn(),
+			onTick
+		});
+		vi.advanceTimersByTime(2000);
+		cancel();
+		vi.advanceTimersByTime(3000);
+		expect(onTick).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('findCellsInRef', () => {
+	it('returns undefined for null refs and refs without ctx', () => {
+		expect(findCellsInRef(null)).toBeUndefined();
+		expect(findCellsInRef({})).toBeUndefined();
+	});
+
+	it('finds the cells array inside the component ctx', () => {
+		const cells = [{ answer: 'A', value: '' }];
+		expect(findCellsInRef({ $$: { ctx: [1, 'x', cells] } })).toBe(cells);
+	});
+
+	it('ignores arrays whose first element is not a cell', () => {
+		expect(findCellsInRef({ $$: { ctx: [[{ foo: 1 }]] } })).toBeUndefined();
+	});
+});
+
+describe('resolveTimerStep', () => {
+	it('ticks when there is no ref', () => {
+		expect(resolveTimerStep(null, false)).toBe('tick');
+	});
+
+	it('ticks when the puzzle is already complete', () => {
+		expect(resolveTimerStep({ $$: { ctx: [] } }, true)).toBe('tick');
+	});
+
+	it('skips when the ref has no cells yet', () => {
+		expect(resolveTimerStep({ $$: { ctx: [] } }, false)).toBe('skip');
+	});
+
+	it('completes when all cells match their answers', () => {
+		const ref = { $$: { ctx: [[{ answer: 'A', value: 'A' }]] } };
+		expect(resolveTimerStep(ref, false)).toBe('complete');
+	});
+
+	it('ticks when some cells do not match', () => {
+		const ref = { $$: { ctx: [[{ answer: 'A', value: 'B' }]] } };
+		expect(resolveTimerStep(ref, false)).toBe('tick');
 	});
 });

--- a/src/routes/preview/helpers/puzzleTimer.ts
+++ b/src/routes/preview/helpers/puzzleTimer.ts
@@ -5,32 +5,48 @@ type TimerCallbacks = {
 	onTick: () => void;
 };
 
-export const createPuzzleTimer = (callbacks: TimerCallbacks): void => {
+type CellLike = { answer?: string; value?: string };
+
+/** Digs the cells array out of the crossword component's internal context. */
+export const findCellsInRef = (ref: unknown): CellLike[] | undefined => {
+	const ctx = (ref as { $$?: { ctx?: unknown[] } })?.$$?.ctx;
+	return ctx?.find(
+		(element: unknown) =>
+			Array.isArray(element) &&
+			(element as CellLike[])[0]?.answer &&
+			(element as CellLike[])[0]?.value !== undefined
+	) as CellLike[] | undefined;
+};
+
+/** One timer step: 'complete' | 'tick' | 'skip' (cells not mounted yet). */
+export const resolveTimerStep = (
+	ref: unknown,
+	isPuzzleComplete: boolean
+): 'complete' | 'tick' | 'skip' => {
+	if (!ref || isPuzzleComplete) return 'tick';
+	const cells = findCellsInRef(ref);
+	if (!cells) return 'skip';
+	const allComplete = cells.every((cell) => cell.answer === cell.value);
+	return allComplete ? 'complete' : 'tick';
+};
+
+/** Starts the preview timer loop. Returns a cancel function for unmount. */
+export const createPuzzleTimer = (callbacks: TimerCallbacks): (() => void) => {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	let cancelled = false;
 	const tick = () => {
-		setTimeout(() => {
-			const ref = callbacks.getRef();
-			if (ref && !callbacks.isPuzzleComplete()) {
-				const cells = (ref as { $$?: { ctx?: unknown[] } })?.$$?.ctx?.find(
-					(element: unknown) =>
-						Array.isArray(element) &&
-						(element as Array<{ answer?: string; value?: string }>)?.[0]?.answer &&
-						(element as Array<{ answer?: string; value?: string }>)?.[0]?.value !== undefined
-				);
-				if (!cells) {
-					return tick();
-				}
-				const allComplete = (cells as Array<{ answer: string; value: string }>).every(
-					(cell) => cell.answer === cell.value
-				);
-				if (allComplete) {
-					return callbacks.onComplete();
-				}
-			}
+		timeout = setTimeout(() => {
+			if (cancelled) return;
+			const step = resolveTimerStep(callbacks.getRef(), callbacks.isPuzzleComplete());
+			if (step === 'complete') return callbacks.onComplete();
+			if (step === 'skip') return tick();
 			callbacks.onTick();
-			if (!callbacks.isPuzzleComplete()) {
-				tick();
-			}
+			if (!callbacks.isPuzzleComplete()) tick();
 		}, 1000);
 	};
 	tick();
+	return () => {
+		cancelled = true;
+		clearTimeout(timeout);
+	};
 };

--- a/src/routes/styles.css
+++ b/src/routes/styles.css
@@ -18,11 +18,13 @@
 	--color-bg-0: rgb(202, 216, 228);
 	--color-bg-1: hsl(209, 36%, 86%);
 	--color-bg-2: hsl(224, 44%, 95%);
-	--color-theme-1: palevioletred;
+	/* Darkened from palevioletred to meet WCAG AA (4.69:1) on --color-bg-body */
+	--color-theme-1: #c2185b;
 	--color-theme-2: #4075a6;
 	--color-text: rgba(0, 0, 0, 0.7);
 	--color-bg-body: #eee8aa;
 	--color-bg-pre: rgba(255, 255, 255, 0.45);
+	--color-bg-nav: rgba(255, 255, 255, 0.7);
 	--column-width: 42rem;
 	--column-margin-top: 4rem;
 	font-family: var(--font-body);
@@ -66,6 +68,7 @@ html {
 		--color-text: rgba(255, 255, 255, 0.87);
 		--color-bg-body: #1a1a1a;
 		--color-bg-pre: rgba(0, 0, 0, 0.45);
+		--color-bg-nav: rgba(255, 255, 255, 0.12);
 	}
 }
 
@@ -78,6 +81,7 @@ html {
 	--color-text: rgba(255, 255, 255, 0.87);
 	--color-bg-body: #1a1a1a;
 	--color-bg-pre: rgba(0, 0, 0, 0.45);
+	--color-bg-nav: rgba(255, 255, 255, 0.12);
 }
 
 body {


### PR DESCRIPTION
## Summary

Fixes from a comprehensive audit, verified end-to-end in a browser (Playwright at iPhone-13 viewport) and by the full test suite (725 tests, CRAP gate, svelte-check, lint, build all green).

### Cursor navigation now matches NYT behavior
New spec suite `cursorSpec.test.js` (17 tests) drives the real engine through `dispatch()`:
- Typing over a filled letter advances to the next **empty** square instead of the next filled one
- Backspace clears in place first; on an empty square it moves back **and clears** that letter
- Next-word jumps resolve the landing cell in the **new** direction (previously used the old direction's clue numbers after wrapping across↔down and could land on an unrelated square) and prefer the first incomplete clue
- Check mode locks verified-correct letters: the cursor skips them and neither typing nor backspace can change them (`isChecking` is now plumbed into the navigation layer)

### Completion integrity
- `usedClear/usedReveal/usedCheck` are now `bind:`-ed through `PuzzleCrossword`/`PuzzleToolbar` — completions were **always** submitted as assist-free because the flags never propagated up
- The Continue flow no longer double-submits a 0-second completion for the next puzzle (child `isComplete` binding stays true for one reactive flush after new clues load)

### Bug fixes
- `SyncLoader` no longer nested inside `<p>` — this caused a `hydration_mismatch` on every page load (verified gone in browser console)
- Login/signup/reset forms use `on:submit|preventDefault` — submit previously triggered a native form post that reloaded the page mid-auth; added `autocomplete` attributes
- On-screen keyboard switched to pointer events — Svelte 5 registers `touchstart` passively so `preventDefault()` was a no-op and each tap double-fired (touch + compat mousedown) on iOS/Android
- Preview timer now returns a cancel function and is cleaned up on destroy (was an orphaned recursive `setTimeout` accumulating across navigations)
- Leaderboard SQL no longer selects `p.email` — emails (PII) were shipped to any client in the payload
- `build-puzzle-collection`: `results.concat(res)` return value was discarded, so multi-date seeding always reported 0 created
- `getHumanReadableDate`: midnight rendered as `0:15am` instead of `12:15am`

### UX
- Light-mode accent darkened `palevioletred` → `#c2185b`: link contrast on the page background was 2.48:1 (WCAG fail), now 4.69:1 (AA)
- Header nav follows the theme in dark mode via new `--color-bg-nav` (was a hardcoded white blob)
- Theme toggle button has an `aria-label`

## Test plan
- [x] `npm run test:crap` — 725 passed, CRAP gate clean
- [x] `npm run lint` / `npm run check` / `npm run build` — clean
- [x] CI 150-line limit respected (cell stepping extracted to `cellNavigation.js`)
- [x] Live browser verification: hydration warnings gone; typed/backspaced/skip-filled cursor behavior confirmed on the real grid; single-fire on-screen keyboard; login submit no longer reloads; dark-mode nav background and AA link color confirmed via computed styles