### PR TITLE
fix(check-mode): treat checked-wrong letters as needing entry

### DIFF
--- a/src/routes/components/crossword/helpers/cellNavigation.js
+++ b/src/routes/components/crossword/helpers/cellNavigation.js
@@ -15,6 +15,17 @@ export function isLockedCell(cell, isChecking) {
 }
 
 /**
+ * A cell still needs a (new) letter: it is empty, or check mode has shown
+ * its current letter to be wrong.
+ * @param {import('./types').Cell} cell
+ * @param {boolean} [isChecking]
+ * @returns {boolean}
+ */
+export function needsEntry(cell, isChecking) {
+	return !cell.value || (!!isChecking && cell.value !== cell.answer);
+}
+
+/**
  * Walks the grid from the focused cell, skipping filled cells when not
  * replacing and always skipping checked-correct (locked) cells.
  * @param {{
@@ -34,7 +45,7 @@ export function getNextCellInDirection({
 	isChecking = false
 }) {
 	const isLandable = (/** @type {import('./types').Cell} */ cell) =>
-		!isLockedCell(cell, isChecking) && (doReplaceFilledCells || !cell.value);
+		!isLockedCell(cell, isChecking) && (doReplaceFilledCells || needsEntry(cell, isChecking));
 	const pos = sortedCellsInDirection.findIndex((d) => d.index === focusedCellIndex);
 	if (pos === -1) return null;
 	const step = diff > 0 ? 1 : -1;
@@ -46,4 +57,16 @@ export function getNextCellInDirection({
 		if (isLandable(sortedCellsInDirection[i])) remaining--;
 	}
 	return sortedCellsInDirection[i].index;
+}
+
+/**
+ * @param {{
+ *   focusedDirection: import('./types').Direction,
+ *   focusedCell: import('./types').Cell
+ * }} params
+ * @returns {import('./types').Direction | null}
+ */
+export function getFlippedDirection({ focusedDirection, focusedCell }) {
+	const newDirection = focusedDirection === 'across' ? 'down' : 'across';
+	return focusedCell.clueNumbers[newDirection] ? newDirection : null;
 }

--- a/src/routes/components/crossword/helpers/cursorSpec.test.js
+++ b/src/routes/components/crossword/helpers/cursorSpec.test.js
@@ -258,3 +258,49 @@ describe('cursor: check mode locks verified-correct letters', () => {
 		expect(h.valueAt(1)).toBe('A');
 	});
 });
+
+describe('cursor: check mode treats checked-WRONG letters as needing entry', () => {
+	// Field report (SHANK bug): with check on, advancing within a word skipped
+	// a square that held an incorrect letter. A checked-wrong square must be a
+	// landing target — only checked-correct squares are skipped.
+	it('advancing lands on a checked-wrong letter instead of skipping it', () => {
+		const h = createHarness({ isChecking: true });
+		h.fill({ 1: 'X' }); // middle of 1A CAT holds a wrong letter
+		h.focus(0, 'across');
+		h.type('C');
+		expect(h.cursor).toBe(1); // must land on the wrong X, not skip to 2
+	});
+
+	it('typing over the wrong letter replaces it and advances', () => {
+		const h = createHarness({ isChecking: true });
+		h.fill({ 0: 'C', 1: 'X' });
+		h.focus(1, 'across');
+		h.type('A');
+		expect(h.valueAt(1)).toBe('A');
+		expect(h.cursor).toBe(2);
+	});
+
+	// Field report (ODES bug): with check on and every square filled, finishing
+	// the last across word jumped to 1-Down's first letter — which was already
+	// checked-correct (locked). It must jump to the first INCORRECT word and
+	// land on its wrong square.
+	it('finishing the last across word jumps to the first incorrect word, not a locked cell', () => {
+		const h = createHarness({ isChecking: true });
+		// Everything filled and correct except index 4 (middle of 4A/2D) is
+		// wrong and index 8 (end of 5A/3D) is empty.
+		h.fill({ 0: 'C', 1: 'A', 2: 'T', 3: 'O', 4: 'X', 5: 'E', 6: 'P', 7: 'E' });
+		h.focus(8, 'across');
+		h.type('N'); // completes 5A, the last across word
+		// The only remaining error is the X at index 4 (in 4A and 2D).
+		expect(h.cursor).toBe(4);
+	});
+
+	it('next-clue in check mode skips fully-correct words even when all are filled', () => {
+		const h = createHarness({ isChecking: true });
+		// All squares filled; only index 4 is wrong. 1A is fully correct.
+		h.fill({ 0: 'C', 1: 'A', 2: 'T', 3: 'O', 4: 'X', 5: 'E', 6: 'P', 7: 'E', 8: 'N' });
+		h.focus(0, 'across');
+		h.act({ type: 'focusClueDiff', diff: 1 }); // "next clue" from 1A
+		expect(h.cursor).toBe(4); // 4A is the first incorrect word; land on its X
+	});
+});

--- a/src/routes/components/crossword/helpers/puzzleCellUpdate.js
+++ b/src/routes/components/crossword/helpers/puzzleCellUpdate.js
@@ -1,4 +1,4 @@
-import { isLockedCell } from './puzzleNavigation.js';
+import { isLockedCell, needsEntry } from './cellNavigation.js';
 
 const NUMBER_OF_STATES_IN_HISTORY = 10;
 
@@ -33,11 +33,13 @@ export function processCellUpdate({
 	const dimension = focusedDirection === 'across' ? 'x' : 'y';
 	const clueIndex = cells[index].clueNumbers[focusedDirection];
 	const allCellsInClue = cells.filter((cell) => cell.clueNumbers[focusedDirection] === clueIndex);
-	const allCellsInClueFilled = allCellsInClue.every((cell) => cell.value);
+	// "Pending" = still needs a letter (empty, or checked-wrong in check mode);
+	// the end of the clue is the last pending square, so a wrong letter later
+	// in the word keeps the cursor inside it instead of jumping to the next clue.
+	const pendingCells = allCellsInClue.filter((cell) => needsEntry(cell, isChecking));
+	const allCellsInClueDone = pendingCells.length === 0;
 
-	const cellsToCheck = allCellsInClueFilled
-		? allCellsInClue
-		: allCellsInClue.filter((cell) => !cell.value);
+	const cellsToCheck = allCellsInClueDone ? allCellsInClue : pendingCells;
 	const cellsInCluePositions = cellsToCheck
 		.map((cell) => cell[dimension])
 		.filter(/** @returns {n is number} */ (n) => Number.isFinite(n));
@@ -60,7 +62,7 @@ export function processCellUpdate({
 	const navigationAction =
 		isAtEndOfClue && diff > 0
 			? { type: 'clueDiff', diff }
-			: { type: 'cellDiff', diff, doReplace: allCellsInClueFilled || doReplaceFilledCells };
+			: { type: 'cellDiff', diff, doReplace: allCellsInClueDone || doReplaceFilledCells };
 
 	return {
 		cells: newCells,

--- a/src/routes/components/crossword/helpers/puzzleNavigation.js
+++ b/src/routes/components/crossword/helpers/puzzleNavigation.js
@@ -1,24 +1,35 @@
 import getCellAfterDiff from './getCellAfterDiff.js';
+import { needsEntry } from './cellNavigation.js';
 
 // Cell-level stepping lives in cellNavigation.js; re-exported here so
 // existing imports keep working.
-export { isLockedCell, getNextCellInDirection } from './cellNavigation.js';
+export { isLockedCell, getNextCellInDirection, getFlippedDirection } from './cellNavigation.js';
+
+/**
+ * A clue needs no further work: every square filled — or, in check mode,
+ * every square verified correct (a wrong letter still needs fixing).
+ * @param {import('./types').Clue} clue
+ * @param {boolean} [isChecking]
+ * @returns {boolean}
+ */
+const isClueDone = (clue, isChecking) => (isChecking ? !!clue.isCorrect : !!clue.isFilled);
 
 /**
  * @param {import('./types').Clue[]} clues
  * @param {import('./types').Direction} focusedDirection
  * @param {number | undefined} currentNumber
- * @param {boolean} allFilled
+ * @param {boolean} allDone
  * @param {number} diff
+ * @param {boolean} [isChecking]
  * @returns {import('./types').Clue[]}
  */
-function findCandidateClues(clues, focusedDirection, currentNumber, allFilled, diff) {
+function findCandidateClues(clues, focusedDirection, currentNumber, allDone, diff, isChecking) {
 	// Coerce a missing clue number to NaN so the relational comparisons below
 	// evaluate to false (matching the prior `> undefined` / `< undefined` behavior).
 	const cn = currentNumber ?? NaN;
 	let candidates = clues.filter(
 		(clue) =>
-			(allFilled || !clue.isFilled) &&
+			(allDone || !isClueDone(clue, isChecking)) &&
 			(diff > 0 ? clue.number > cn : clue.number < cn) &&
 			clue.direction === focusedDirection
 	);
@@ -31,30 +42,35 @@ function findCandidateClues(clues, focusedDirection, currentNumber, allFilled, d
  * @param {number} diff
  * @param {import('./types').Clue[]} clues
  * @param {import('./types').Direction} focusedDirection
+ * @param {boolean} [isChecking]
  * @returns {{ clue: import('./types').Clue | undefined, direction: import('./types').Direction }}
  */
-function resolveNextClue(candidates, diff, clues, focusedDirection) {
+function resolveNextClue(candidates, diff, clues, focusedDirection, isChecking) {
 	const nextClue = candidates[Math.abs(diff) - 1];
 	if (nextClue) return { clue: nextClue, direction: focusedDirection };
-	// Wrap into the other direction, preferring its first incomplete clue.
+	// Wrap into the other direction, preferring its first not-done clue.
 	const newDirection = focusedDirection === 'across' ? 'down' : 'across';
 	const wrapped = clues.filter((c) => c.direction === newDirection);
-	return { clue: wrapped.find((c) => !c.isFilled) || wrapped[0], direction: newDirection };
+	return {
+		clue: wrapped.find((c) => !isClueDone(c, isChecking)) || wrapped[0],
+		direction: newDirection
+	};
 }
 
 /**
  * @param {import('./types').Cell[]} sortedCells
  * @param {number | undefined} clueNumber
  * @param {import('./types').Direction} focusedDirection
- * @param {boolean} allFilled
+ * @param {boolean} allDone
+ * @param {boolean} [isChecking]
  * @returns {Partial<import('./types').Cell>}
  */
-function findCellForClue(sortedCells, clueNumber, focusedDirection, allFilled) {
+function findCellForClue(sortedCells, clueNumber, focusedDirection, allDone, isChecking) {
+	const inClue = (/** @type {import('./types').Cell} */ cell) =>
+		cell.clueNumbers[focusedDirection] === clueNumber;
 	return (
-		sortedCells.find(
-			(cell) => (allFilled || !cell.value) && cell.clueNumbers[focusedDirection] === clueNumber
-		) ||
-		sortedCells.find((cell) => cell.clueNumbers[focusedDirection] === clueNumber) ||
+		sortedCells.find((cell) => inClue(cell) && (needsEntry(cell, isChecking) || allDone)) ||
+		sortedCells.find(inClue) ||
 		{}
 	);
 }
@@ -66,7 +82,8 @@ function findCellForClue(sortedCells, clueNumber, focusedDirection, allFilled) {
  *   focusedDirection: import('./types').Direction,
  *   sortedCellsInDirection: import('./types').Cell[],
  *   diff?: number,
- *   cells?: import('./types').Cell[]
+ *   cells?: import('./types').Cell[],
+ *   isChecking?: boolean
  * }} params
  * @returns {{ focusedCellIndex: number, focusedDirection: import('./types').Direction }}
  */
@@ -75,25 +92,37 @@ export function getNextClueCell({
 	focusedCell,
 	focusedDirection,
 	sortedCellsInDirection,
-	diff = 1
+	diff = 1,
+	isChecking = false
 }) {
 	const currentNumber = focusedCell.clueNumbers[focusedDirection];
-	const allFilled = clues.filter((c) => c.direction === focusedDirection).every((c) => c.isFilled);
-	const candidates = findCandidateClues(clues, focusedDirection, currentNumber, allFilled, diff);
+	const allDone = clues
+		.filter((c) => c.direction === focusedDirection)
+		.every((c) => isClueDone(c, isChecking));
+	const candidates = findCandidateClues(
+		clues,
+		focusedDirection,
+		currentNumber,
+		allDone,
+		diff,
+		isChecking
+	);
 	const { clue: nextClue, direction: newDirection } = resolveNextClue(
 		candidates,
 		diff,
 		clues,
-		focusedDirection
+		focusedDirection,
+		isChecking
 	);
 	// Resolve the landing cell against the direction the clue belongs to (it
 	// may differ from focusedDirection after wrapping across<->down). After a
-	// wrap, allFilled described the old direction, so prefer empty cells.
+	// wrap, allDone described the old direction, so prefer needs-entry cells.
 	const nextCell = findCellForClue(
 		sortedCellsInDirection,
 		nextClue?.number,
 		newDirection,
-		allFilled && newDirection === focusedDirection
+		allDone && newDirection === focusedDirection,
+		isChecking
 	);
 	return { focusedCellIndex: nextCell.index ?? 0, focusedDirection: newDirection };
 }
@@ -113,16 +142,4 @@ export function getMoveFocusResult({ direction, diff, cells, focusedDirection, f
 	const nextCell = getCellAfterDiff({ diff, cells, direction, focusedCell });
 	if (!nextCell) return null;
 	return { focusedCellIndex: nextCell.index };
-}
-
-/**
- * @param {{
- *   focusedDirection: import('./types').Direction,
- *   focusedCell: import('./types').Cell
- * }} params
- * @returns {import('./types').Direction | null}
- */
-export function getFlippedDirection({ focusedDirection, focusedCell }) {
-	const newDirection = focusedDirection === 'across' ? 'down' : 'across';
-	return focusedCell.clueNumbers[newDirection] ? newDirection : null;
 }

--- a/src/routes/components/crossword/helpers/puzzleStateResolvers.js
+++ b/src/routes/components/crossword/helpers/puzzleStateResolvers.js
@@ -36,7 +36,8 @@ export function resolveFocusClueDiff(state, diff) {
 		focusedCell: state.focusedCell,
 		focusedDirection: state.focusedDirection,
 		sortedCellsInDirection: state.sortedCellsInDirection,
-		diff
+		diff,
+		isChecking: state.isChecking
 	});
 	/** @type {import('./types').StatePatch} */
 	const patch = { focusedCellIndex: r.focusedCellIndex };


### PR DESCRIPTION
## Summary

Fixes two field-reported cursor bugs in TestFlight build 202608311525, both in check mode:

1. **SHANK bug** — typing through a word skipped a square that held an *incorrect* letter. Cell advancement treated any filled square as done once the whole word was filled; now a checked-wrong square is a landing target.
2. **ODES bug** — finishing the last across word jumped to 1-Down's first letter even though that letter was already checked-correct (locked). Word-to-word jumps keyed on `isFilled`, which is blind to correctness; in check mode they now key on `isCorrect` and land on the word's wrong/empty square.

Core change: `needsEntry(cell, isChecking)` — a square needs a letter if it's empty **or** check has shown it wrong. Used by cell stepping, end-of-clue detection, and clue-jump landing. `getFlippedDirection` moved to `cellNavigation.js` to stay under the 150-line CI limit.

## Test plan
- [x] 4 new regression tests reproducing both reported scenarios (fail on `main`, pass here)
- [x] Full suite 729 tests green, CRAP gate, lint, svelte-check, build
- [x] Live browser repro: planted a wrong letter mid-word, enabled Check, typed through — cursor landed on the wrong square and the fix replaced it